### PR TITLE
ctd-cast-discrete-samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 dashboard/public/HITL_notes/
 dashboard/public/QAQC_plots/
 dashboard/public/spectrograms/
+dashboard/public/discrete/
 
-#mac
+# mac
 .DS_Store

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,6 +1,5 @@
 # Project
 /public/QAQC_plots/
-/public/discrete/
 
 # Nuxt
 .nuxt

--- a/dashboard/app/components/SideBar.vue
+++ b/dashboard/app/components/SideBar.vue
@@ -168,7 +168,7 @@ const accordionItems = $computed(() => {
     >
       Discrete Data
     </u-button>
-    <div class="bg-white h-px mt-2 mb-1 opacity-20" />
+    <div class="bg-white h-px mb-1 mt-2 opacity-20" />
     <u-button
       class="hover:text-white mt-1 px-0 sm:text-[16px] text-[13px] text-gray-300"
       to="/event-report"

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -1712,9 +1712,12 @@ async function copyToClipboard() {
                 <div class="flex flex-1 flex-row shrink space-x-2">
                   <u-form-field class="basis-0 grow min-w-24" label="Year" size="sm">
                     <template #hint>
-                      <u-tooltip text="Show separate chart-series for each CTD cast collected.">
+                      <u-tooltip text="Show separate chart series for each CTD cast collected.">
                         <u-checkbox
-                          class="flex-row-reverse gap-1 items-center"
+                          :class="[
+                            'flex-row-reverse gap-1 items-center hover:opacity-100',
+                            series.showCasts ? 'opacity-100' : 'opacity-80',
+                          ]"
                           label="Show Casts"
                           :model-value="series.showCasts ?? false"
                           size="xs"

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -1182,13 +1182,14 @@ watchEffect((onInvalidate) => {
       sameOriginal(charted.original, clicked.original),
     )
     const seriesIndex = state.series.findIndex((current) => sameOriginal(clicked.original, current))
+    const series = seriesIndex !== -1 ? state.series[seriesIndex]! : null
 
     // When shift is held, toggle all series in the same original group together.
     if (isShiftPressed) {
       for (const charted of group) {
         legendSelectionOverrides.set(charted.name, isSelected)
       }
-      if (seriesIndex !== -1 && state.series[seriesIndex]!.enabled !== isSelected) {
+      if (series != null && series.enabled !== isSelected) {
         setSeriesField(seriesIndex, 'enabled', isSelected)
       }
       return
@@ -1198,7 +1199,7 @@ watchEffect((onInvalidate) => {
     legendSelectionOverrides.set(clickedName, isSelected)
 
     // Sync the parent `enabled` state when all sub-series in the group agree.
-    if (seriesIndex !== -1) {
+    if (series != null) {
       const allSelected = group.every(
         (charted) => legendSelectionOverrides.get(charted.name) ?? charted.original.enabled,
       )
@@ -1206,9 +1207,9 @@ watchEffect((onInvalidate) => {
         (charted) => !(legendSelectionOverrides.get(charted.name) ?? charted.original.enabled),
       )
 
-      if (noneSelected && state.series[seriesIndex]!.enabled) {
+      if (noneSelected && series.enabled) {
         setSeriesField(seriesIndex, 'enabled', false)
-      } else if (allSelected && !state.series[seriesIndex]!.enabled) {
+      } else if (allSelected && !series.enabled) {
         setSeriesField(seriesIndex, 'enabled', true)
       }
     }

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -132,7 +132,7 @@ const ctrlKey = isMac ? 'Command' : 'Ctrl'
 const historyOmit: ReadonlyArray<keyof typeof state> = ['zoom', 'seriesCollapsed']
 // Implement undo/redo for modifying the page's state.
 const history = useUndo({
-  initial: state,
+  current: () => state,
   onUndo(values) {
     Object.assign(state, omit(values, historyOmit))
   },
@@ -323,7 +323,9 @@ const chartedSeries = $computed(() => {
           type: series.display,
           z: i + 2,
           emphasis: { focus: 'series' },
-          ...({ showSymbol: series.display !== 'line' } as any),
+          ...({
+            showSymbol: series.display !== 'line' || !isCTDCastSeries(series),
+          } as any),
           data: paired.map(({ point }) => point),
           sources: paired.map(({ source }) => source),
           itemStyle: { color },
@@ -510,18 +512,26 @@ function isInvertedAxis(axis: string) {
   return lower.includes('depth') || lower.includes('pressure')
 }
 
-// Build axis select items from plottable fields, inserting a separator between
-// CTD Cast and non-CTD Cast fields. If the opposite axis has a CTD Cast value
-// selected, CTD Cast fields come first; otherwise non-CTD Cast fields come first.
+function isCTDCastField(field: string | undefined): boolean {
+  return typeof field === 'string' && field.startsWith('CTD Cast ')
+}
+
+function isCTDCastSeries(series: { x?: string; y?: string }): boolean {
+  return isCTDCastField(series.x) || isCTDCastField(series.y)
+}
+
+// Build axis select items from plottable fields, inserting a separator between CTD Cast and non-CTD
+// Cast fields. If the opposite axis has a CTD Cast value selected, CTD Cast fields come first,
+// otherwise non-CTD Cast fields come first.
 function axisSelectItems(series: PartialSeries, axis: 'x' | 'y') {
   const opposite = axis === 'x' ? 'y' : 'x'
   const oppositeValue = axis === 'x' ? series.y : series.x
-  const castFirst = typeof oppositeValue === 'string' && oppositeValue.startsWith('CTD Cast ')
+  const castFirst = isCTDCastField(oppositeValue)
 
   const castFields: string[] = []
   const otherFields: string[] = []
   for (const field of discrete.plottableFields) {
-    if (field.startsWith('CTD Cast ')) {
+    if (isCTDCastField(field)) {
       castFields.push(field)
     } else {
       otherFields.push(field)
@@ -533,7 +543,7 @@ function axisSelectItems(series: PartialSeries, axis: 'x' | 'y') {
   const items: any[] = []
   let prevWasCast: boolean | null = null
   for (const field of ordered) {
-    const isCast = field.startsWith('CTD Cast ')
+    const isCast = isCTDCastField(field)
     if (prevWasCast !== null && isCast !== prevWasCast) {
       items.push({ type: 'separator' })
     }
@@ -610,7 +620,8 @@ const option = $computed(() => {
           const longitude = source != null ? findFieldValue(source.data, 'longitude') : null
           const coordinateLine =
             latitude != null && longitude != null
-              ? '<span class="text-gray-300">' +
+              ? '<span class="text-gray-500">Cast Location</span> ' +
+                '<span class="text-gray-400">' +
                 `(${formatValue(latitude, 6)}°, ${formatValue(longitude, 6)}°)` +
                 '</span><br/>'
               : ''
@@ -749,7 +760,7 @@ function addSeries({
 
   state.series.splice(index, 0, created)
   if (saveUndo) {
-    history.save(state)
+    history.save()
   }
 
   return created
@@ -767,7 +778,7 @@ function removeSeries(index?: number) {
   }
 
   const removed = state.series.splice(index, 1)[0]
-  history.save(state)
+  history.save()
 
   return removed
 }
@@ -779,7 +790,7 @@ function removeOtherSeries(index: number) {
   }
 
   state.series = [series]
-  history.save(state)
+  history.save()
 }
 
 // Move the series at the given index up one position, if possible.
@@ -793,7 +804,7 @@ function moveSeriesUp(index: number) {
   state.series[index - 1] = series
   state.series[index] = previous
 
-  history.save(state)
+  history.save()
 }
 
 // Move the series at the given index down one position, if possible.
@@ -807,7 +818,7 @@ function moveSeriesDown(index: number) {
   state.series[index + 1] = series
   state.series[index] = next
 
-  history.save(state)
+  history.save()
 }
 
 // Indicates the "Shift" key is currently held.
@@ -843,19 +854,18 @@ useEventListener('keyup', (event: KeyboardEvent) => {
 })
 
 // Reset modifier keys when the browser tab loses focus. Otherwise, they can get stuck in the
-// pressed state if the user switches away from the page while holding them, due to the key up event
-// never being received.
+// pressed state if the user switches away from the page while holding them, due to the key up
+// event never being received.
 useEventListener('blur', () => {
   isShiftPressed = false
   isCtrlPressed = false
 })
 
-// Return a new series object with the provided `field` set to `value` while keeping the order
-// of fields consistent with the `SeriesSchema` definition. The reason being: the JSON of each
-// series object is displayed in the browser's URL, and having a consistent order with `asset`
-// displayed first makes the URL more readable. In addition, when opening a shared link to this
-// page, the URL won't appear to suddenly change when the data is re-parsed from the URL on load
-// anyway.
+// Return a new series object with the provided `field` set to `value` while keeping the order of
+// fields consistent with the `SeriesSchema` definition. The reason being: the JSON of each series
+// object is displayed in the browser's URL, and having a consistent order with `asset` displayed
+// first makes the URL more readable. In addition, when opening a shared link to this page, the URL
+// won't appear to suddenly change when the data is re-parsed from the URL on load anyway.
 function withSeriesFieldSet(series: PartialSeries, field: keyof PartialSeries, value: any) {
   const data = { ...series, [field]: value }
   try {
@@ -893,13 +903,13 @@ function setSeriesField<K extends keyof PartialSeries>(
     // Apply the change to all series.
     state.series = state.series.map((current) => withSeriesFieldSet(current, field, value))
     if (saveUndo) {
-      history.save(state)
+      history.save()
     }
   } else {
     // Apply the change to just the current series.
     state.series[index] = withSeriesFieldSet(series, field, value)
     if (saveUndo) {
-      history.save(state)
+      history.save()
     }
   }
 }
@@ -970,13 +980,13 @@ function duplicateSeriesForAllYears(
   clonedOriginal.color = series.color
 
   // Save undo history.
-  history.save(state)
+  history.save()
   return clones
 }
 
 // Create series with the same (`x`, `y`, `year`) of the given series at `index` for all assets. If
-// `withMatchingData` is `true`, do this only for assets for which we have data for matching
-// the original series' filter fields. All generated series objects will be inserted after `index`.
+// `withMatchingData` is `true`, do this only for assets for which we have data matching the
+// original series' filter fields. All generated series objects will be inserted after `index`.
 function duplicateSeriesForAllAssets(
   index: number,
   { withMatchingData = true }: { withMatchingData?: boolean } = {},
@@ -1020,7 +1030,7 @@ function duplicateSeriesForAllAssets(
   }
 
   // Save undo history.
-  history.save(state)
+  history.save()
   return clones
 }
 
@@ -1118,7 +1128,7 @@ watchEffect((onInvalidate) => {
       }
     }
 
-    history.save(state)
+    history.save()
   })
 
   // Unregister event handlers when invalidated.
@@ -1286,7 +1296,7 @@ async function copyToClipboard() {
                     { label: 'From Zero (Y)', value: 'from-zero-y' },
                   ]"
                   size="sm"
-                  @update:model-value="history.save(state)"
+                  @update:model-value="history.save()"
                 />
               </u-tooltip>
             </u-form-field>
@@ -1317,7 +1327,7 @@ async function copyToClipboard() {
                       series.y = x
                     }
 
-                    history.save(state)
+                    history.save()
                   }
                 "
               >
@@ -1440,7 +1450,7 @@ async function copyToClipboard() {
                 () => {
                   state.series = []
                   state.seriesCollapsed = false
-                  history.save(state)
+                  history.save()
                 }
               "
             />

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -1767,13 +1767,14 @@ async function copyToClipboard() {
                       <u-tooltip text="Show separate chart series for each CTD cast collected.">
                         <u-checkbox
                           :class="[
-                            'flex-row-reverse gap-1 items-center hover:opacity-100',
-                            series.showCasts ? 'opacity-100' : 'opacity-80',
+                            'flex-row-reverse gap-1 items-center hover:opacity-100 ',
+                            'whitespace-nowrap mr-3',
+                            series.showCasts ? 'opacity-100' : 'opacity-70',
                           ]"
                           label="Show Casts"
                           :model-value="series.showCasts ?? false"
                           size="xs"
-                          :ui="{ label: 'text-[11px]' }"
+                          :ui="{ label: 'text-[9px]' }"
                           @update:model-value="
                             (value) => setSeriesField(i, 'showCasts', value && true)
                           "

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -920,6 +920,23 @@ function setSeriesField<K extends keyof PartialSeries>(
     value = undefined
   }
 
+  // Clear legend selection overrides for this series when toggling enabled, so cast sub-series
+  // reset to match the parent state.
+  if (field === 'enabled') {
+    const target = state.series[index]
+    for (const charted of chartedSeries) {
+      const original = charted.original
+      if (
+        original.asset === target?.asset &&
+        original.x === target?.x &&
+        original.y === target?.y &&
+        original.year === target?.year
+      ) {
+        legendSelectionOverrides.delete(charted.name)
+      }
+    }
+  }
+
   // The series (possibly) being modified.
   const series = state.series[index]
   if (series == null) {

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -145,26 +145,9 @@ type Series = Required<PartialSeries>
 // Fields in series objects used for filtering samples.
 type SampleFilter = Pick<PartialSeries, 'asset' | 'x' | 'y' | 'year'>
 
-// Assets that can be selected for plotting, with CTD Cast assets sorted last.
-const selectableAssets = $computed(() => {
-  const assets = compact(discrete.assets.filter((asset) => asset !== 'PI_REQUEST'))
-  return orderBy(assets, [(asset) => (getAssetGroup(asset) === 'ctd-cast' ? 1 : 0)])
-})
-
-function getAssetGroup(asset: string): 'normal' | 'ctd-cast' {
-  if (asset.startsWith('CTD Cast (')) {
-    return 'ctd-cast'
-  }
-  return 'normal'
-}
-
-// Return the subset of selectable assets that belong to the same group (CTD Cast or non-CTD Cast)
-// as the given asset. Used when duplicating a series for all assets of the same kind. If the asset
-// is `null` or `undefined`, return all "normal" assets.
-function peerAssetsFor(asset: string | null | undefined): string[] {
-  const group = asset != null ? getAssetGroup(asset) : 'normal'
-  return selectableAssets.filter((asset) => getAssetGroup(asset) === group)
-}
+const selectableAssets = $computed(() =>
+  compact(discrete.assets.filter((asset) => asset !== 'PI_REQUEST')),
+)
 
 // All series with filter fields completely filled out.
 const series = $computed(
@@ -217,8 +200,21 @@ function hasDataFor(filter: SampleFilter) {
   return getSamplesFor(filter).length > 0
 }
 
-function getNoDataIndicator(filter: SampleFilter) {
-  return !hasDataFor(filter) ? ' (No Data)' : ''
+function getNoDataIndicator(
+  filter: SampleFilter,
+  forOppositeAxis?: { opposite: 'x' | 'y'; value: string | undefined },
+) {
+  if (!hasDataFor(filter)) {
+    return ' (No Data)'
+  }
+
+  if (forOppositeAxis != null) {
+    if (!hasDataFor({ ...filter, [forOppositeAxis.opposite]: forOppositeAxis.value })) {
+      return ` (No Data for ${forOppositeAxis.opposite.toUpperCase()})`
+    }
+  }
+
+  return ''
 }
 
 const currentYear = new Date().getFullYear()
@@ -287,7 +283,9 @@ const chartedSeries = $computed(() => {
       id: i,
       name,
       type: series.display,
+      z: i + 2,
       emphasis: { focus: 'series' },
+      ...({ showSymbol: series.display !== 'line' } as any),
       data,
       itemStyle: { color: series.color },
       lineStyle: series.display === 'line' ? { color: series.color } : undefined,
@@ -384,12 +382,12 @@ function computeDataExtents(selectedOnly: boolean) {
 
   return {
     x: {
-      min: minOf(series.flatMap((series) => series.data.map(([x]) => x))) ?? 0,
-      max: maxOf(series.flatMap((series) => series.data.map(([x]) => x))) ?? 1,
+      min: minOf(series.flatMap((series) => series.data.map(([x]: any) => x))) ?? 0,
+      max: maxOf(series.flatMap((series) => series.data.map(([x]: any) => x))) ?? 1,
     },
     y: {
-      min: minOf(series.flatMap((series) => series.data.map(([_, y]) => y))) ?? 0,
-      max: maxOf(series.flatMap((series) => series.data.map(([_, y]) => y))) ?? 1,
+      min: minOf(series.flatMap((series) => series.data.map(([_, y]: any) => y))) ?? 0,
+      max: maxOf(series.flatMap((series) => series.data.map(([_, y]: any) => y))) ?? 1,
     },
   }
 }
@@ -544,12 +542,14 @@ const option = $computed(() => {
         xAxisIndex: 0,
         moveOnMouseWheel: 'alt',
         disabled: isShiftPressed,
+        filterMode: 'none',
       },
       {
         id: 'y-inside',
         type: 'inside',
         yAxisIndex: 0,
         disabled: isCtrlPressed,
+        filterMode: 'none',
       },
       {
         id: 'x-slider',
@@ -558,6 +558,7 @@ const option = $computed(() => {
         height: 22,
         showDetail: false,
         showDataShadow: false,
+        filterMode: 'none',
       },
       {
         id: 'y-slider',
@@ -568,6 +569,7 @@ const option = $computed(() => {
         right: 4,
         showDetail: false,
         showDataShadow: false,
+        filterMode: 'none',
       },
     ],
     legend: {
@@ -859,11 +861,10 @@ function duplicateSeriesForAllAssets(
     return
   }
 
-  const peers = peerAssetsFor(series.asset)
   let assetsToGenerate = withMatchingData
     ? // All assets for which we have data matching the series' `x`, `y`, and `year`.
-      peers.filter((current) => hasDataFor({ ...series, asset: current }))
-    : peers
+      selectableAssets.filter((current) => hasDataFor({ ...series, asset: current }))
+    : selectableAssets
 
   if (series.asset != null) {
     // If the original series has an `asset` set and it's in the list, we don't need to generate it.
@@ -1390,9 +1391,7 @@ async function copyToClipboard() {
                           { type: 'separator' },
                           {
                             icon: 'i-lucide-square-stack',
-                            label:
-                              'Duplicate For All Assets ' +
-                              `(${peerAssetsFor(series.asset).length})`,
+                            label: 'Duplicate For All Assets ' + `(${selectableAssets.length})`,
                             onSelect: () =>
                               duplicateSeriesForAllAssets(i, { withMatchingData: false }),
                           },
@@ -1403,9 +1402,7 @@ async function copyToClipboard() {
                               uniq(
                                 getSamplesFor(omit(series, ['asset']))
                                   .map((current) => current.asset)
-                                  .filter((asset) =>
-                                    peerAssetsFor(series.asset).includes(asset ?? ''),
-                                  ),
+                                  .filter((asset) => selectableAssets.includes(asset ?? '')),
                               ).length +
                               ')',
                             onSelect: () =>
@@ -1452,7 +1449,12 @@ async function copyToClipboard() {
                     class="w-full"
                     :items="
                       discrete.plottableFields.map((field) => ({
-                        label: `${field} ${getNoDataIndicator({ asset: series.asset, x: field })}`,
+                        label:
+                          `${field} ` +
+                          getNoDataIndicator(
+                            { asset: series.asset, x: field },
+                            { opposite: 'y', value: series.y },
+                          ),
                         value: field as string | null,
                       }))
                     "
@@ -1465,12 +1467,23 @@ async function copyToClipboard() {
                     <template #item-label="{ item }">
                       <span
                         :class="
-                          !hasDataFor({ asset: series.asset, x: (item as any).value }) &&
-                          'opacity-75'
+                          !hasDataFor({
+                            asset: series.asset,
+                            x: (item as any).value,
+                            y: series.y,
+                          }) && 'opacity-75'
                         "
                       >
                         {{ (item as any).value }}
-                        {{ getNoDataIndicator({ asset: series.asset, x: (item as any).value }) }}
+                        {{
+                          getNoDataIndicator(
+                            {
+                              asset: series.asset,
+                              x: (item as any).value,
+                            },
+                            { opposite: 'y', value: series.y },
+                          )
+                        }}
                         {{ itemLabelModifier }}
                       </span>
                     </template>
@@ -1497,7 +1510,12 @@ async function copyToClipboard() {
                     class="w-full"
                     :items="
                       discrete.plottableFields.map((field) => ({
-                        label: `${field} ${getNoDataIndicator({ asset: series.asset, y: field })}`,
+                        label:
+                          `${field} ` +
+                          getNoDataIndicator(
+                            { asset: series.asset, y: field },
+                            { opposite: 'x', value: series.x },
+                          ),
                         value: field ?? null,
                       }))
                     "
@@ -1510,12 +1528,23 @@ async function copyToClipboard() {
                     <template #item-label="{ item }">
                       <span
                         :class="
-                          !hasDataFor({ asset: series.asset, y: (item as any).value }) &&
-                          'opacity-75'
+                          !hasDataFor({
+                            asset: series.asset,
+                            x: series.x,
+                            y: (item as any).value,
+                          }) && 'opacity-75'
                         "
                       >
                         {{ (item as any).value }}
-                        {{ getNoDataIndicator({ asset: series.asset, x: (item as any).value }) }}
+                        {{
+                          getNoDataIndicator(
+                            {
+                              asset: series.asset,
+                              y: (item as any).value,
+                            },
+                            { opposite: 'x', value: series.x },
+                          )
+                        }}
                         {{ itemLabelModifier }}
                       </span>
                     </template>

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -526,6 +526,19 @@ function isInvertedAxis(axis: string) {
   return lower.includes('depth') || lower.includes('pressure')
 }
 
+// Compare two series-like objects by their identifying fields rather than reference.
+function sameOriginal(
+  left: { asset?: string; x?: string; y?: string; year?: number },
+  right: { asset?: string; x?: string; y?: string; year?: number },
+): boolean {
+  return (
+    left.asset === right.asset &&
+    left.x === right.x &&
+    left.y === right.y &&
+    left.year === right.year
+  )
+}
+
 function isCTDCastField(field: string | undefined): boolean {
   return typeof field === 'string' && field.startsWith('CTD Cast ')
 }
@@ -624,7 +637,7 @@ const option = $computed(() => {
             color,
           } = point
 
-          const series = chartedSeries.find((s) => s.name === seriesName)
+          const series = chartedSeries.find((charted) => charted.name === seriesName)
           if (series == null) {
             continue
           }
@@ -924,15 +937,11 @@ function setSeriesField<K extends keyof PartialSeries>(
   // reset to match the parent state.
   if (field === 'enabled') {
     const target = state.series[index]
-    for (const charted of chartedSeries) {
-      const original = charted.original
-      if (
-        original.asset === target?.asset &&
-        original.x === target?.x &&
-        original.y === target?.y &&
-        original.year === target?.year
-      ) {
-        legendSelectionOverrides.delete(charted.name)
+    if (target != null) {
+      for (const charted of chartedSeries) {
+        if (sameOriginal(charted.original, target)) {
+          legendSelectionOverrides.delete(charted.name)
+        }
       }
     }
   }
@@ -1165,8 +1174,10 @@ watchEffect((onInvalidate) => {
     }
 
     const isSelected = selected[clickedName] ?? true
-    const group = chartedSeries.filter((charted) => charted.original === clicked.original)
-    const seriesIndex = series.indexOf(clicked.original)
+    const group = chartedSeries.filter((charted) =>
+      sameOriginal(charted.original, clicked.original),
+    )
+    const seriesIndex = state.series.findIndex((current) => sameOriginal(clicked.original, current))
 
     // When shift is held, toggle all series in the same original group together.
     if (isShiftPressed) {

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -11,8 +11,8 @@ import {
   uniq,
   uniqBy,
   upperFirst,
-  min,
-  max,
+  min as minOf,
+  max as maxOf,
   range,
   omit,
 } from 'lodash-es'
@@ -29,9 +29,6 @@ import { useUndo } from '~/undo'
 useHead({
   titleTemplate: 'Discrete Data | %s',
 })
-
-const minOf = min
-const maxOf = max
 
 // Reference to the `Chart` component instance, used to dispatch actions and listen for events.
 const chartInstance = $ref<InstanceType<typeof Chart> | null>(null)

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -119,7 +119,7 @@ const state = usePersisted({
       .default(createDefaultZoom)
       .catch(createDefaultZoom),
   }),
-  methods: [{ type: 'url' }],
+  methods: [{ type: 'url', omit: ['id'] }],
 })
 
 onMounted(() => {

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -348,7 +348,11 @@ const chartedSeries = $computed(() => {
         castSamples,
         (sample) => `${sample.data['Cast']}__${sample.timestamp.toString()}`,
       )
-      const castKeys = Object.keys(casts).sort()
+      const castKeys = Object.keys(casts).sort((left, right) => {
+        const leftTimestamp = casts[left]![0]!.timestamp
+        const rightTimestamp = casts[right]![0]!.timestamp
+        return leftTimestamp.compare(rightTimestamp)
+      })
 
       // Check if any casts share the same date (need cast number to disambiguate).
       const castDates = castKeys.map((key) => {

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -66,7 +66,11 @@ function getRandomColor() {
   )
 }
 
-// Schema for data series objects in form.
+// Generate a random UUID for a series.
+function createSeriesId() {
+  return crypto.randomUUID()
+}
+
 const SeriesSchema = Zod.object({
   // Note that we need to convert these possibly `undefined` values to `null` before passing them to
   // the `model-value` of a NuxtUI select or select menu component because they seem to treat
@@ -83,8 +87,8 @@ const SeriesSchema = Zod.object({
   color: Zod.string().default(chartColors[0]),
   // Internal ID for tracking series identity. Last so it appears at the end of the URL.
   id: Zod.string()
-    .default(() => crypto.randomUUID())
-    .catch(() => crypto.randomUUID()),
+    .default(() => createSeriesId())
+    .catch(() => createSeriesId()),
 })
 
 function createDefaultZoom(): ZoomState {
@@ -797,6 +801,7 @@ function addSeries({
     ...cloneDeep(copy ?? {}),
     color,
     ...changes,
+    id: createSeriesId(),
   })
 
   state.series.splice(index, 0, created)

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
 import { useEventListener } from '@vueuse/core'
+import Color from 'color'
 import type { SeriesOption } from 'echarts'
 import {
   cloneDeep,
   compact,
+  groupBy,
   orderBy,
   truncate,
   uniq,
@@ -18,7 +20,7 @@ import Zod from 'zod'
 
 import type { Option } from '~/chart'
 import type Chart from '~/components/Chart.vue'
-import type { Sample, SampleSchemaFieldDefinition, SampleValue } from '~/discrete'
+import type { Sample, SampleData, SampleSchemaFieldDefinition, SampleValue } from '~/discrete'
 import { useDiscrete } from '~/discrete'
 import { usePersisted } from '~/persisted'
 import { isMac } from '~/platform'
@@ -81,6 +83,7 @@ const SeriesSchema = Zod.object({
   year: Zod.number().optional(),
   display: Zod.enum(['scatter', 'line']).default('scatter'),
   enabled: Zod.boolean().default(true),
+  showCasts: Zod.boolean().default(false).catch(false),
   color: Zod.string().default(chartColors[0]),
 })
 
@@ -236,6 +239,8 @@ type ChartedSeries = Omit<SeriesOption, 'data'> & {
 
   name: string
   data: [SampleValue, SampleValue][]
+  // Source samples aligned with `data` for tooltip access.
+  sources: Sample[]
   itemStyle?: any
   lineStyle?: any
 
@@ -244,38 +249,105 @@ type ChartedSeries = Omit<SeriesOption, 'data'> & {
   yAxisLabel: string
 }
 
+// Generate a color shifted from a base color, enough to distinguish but close enough to recognize.
+function varyColor(baseColor: string, index: number, length: number): string {
+  if (index === 0) {
+    return baseColor
+  }
+
+  const base = Color(baseColor).hsl()
+  const maxSpread = Math.min(60, length * 20)
+  const hueStep = maxSpread / length
+  const lightnessStep = 14 / length
+  return base
+    .hue((base.hue() + hueStep * index) % 360)
+    .lightness(Math.max(30, Math.min(70, base.lightness() + lightnessStep * index - 7)))
+    .hex()
+}
+
 // Computed ECharts series options with data points.
 const chartedSeries = $computed(() => {
-  return series.map((series, i) => {
-    let data = getSamplesFor(series)
-      // Convert samples to [X value, Y value] data points for ECharts.
-      .map((sample) => [sample.data[series.x], sample.data[series.y]] as [SampleValue, SampleValue])
-      // Shouldn't be necessary because the samples match, but just in case.
-      .filter(([x, y]) => x != null && y != null)
+  return series.flatMap((series, i) => {
+    const samples = getSamplesFor(series)
 
     // We need to create unique series names depending on which axes are the same/different.
-    let name: string
+    let baseName: string
     if (allAxesAreSame) {
-      // All axes are the same, so just specify asset and year.
-      name = `${series.asset} (${series.year})`
+      baseName = `${series.asset} (${series.year})`
     } else if (xAxesAreSame) {
-      // Only X axes are the same, so specify asset, year and the distinct Y axis.
-      name = `${series.asset} (${series.year}) — ${series.y}`
+      baseName = `${series.asset} (${series.year}) — ${series.y}`
     } else if (yAxesAreSame) {
-      // Only Y axes are the same, so specify asset, year and the distinct X axis.
-      name = `${series.asset} (${series.year}) — ${series.x}`
+      baseName = `${series.asset} (${series.year}) — ${series.x}`
     } else {
-      // Both axes are the different, so specify asset, year, and both the Y and X axis.
-      name = `${series.asset} (${series.year}) — ${series.y} / ${series.x}`
+      baseName = `${series.asset} (${series.year}) — ${series.y} / ${series.x}`
     }
 
-    if (data.length === 0) {
+    const castSamples = series.showCasts
+      ? samples.filter((sample) => sample.data['Cast'] != null)
+      : []
+    if (castSamples.length > 0) {
+      const casts = groupBy(
+        castSamples,
+        (sample) => `${sample.data['Cast']}__${sample.timestamp.toString()}`,
+      )
+      const castKeys = Object.keys(casts).sort()
+
+      // Check if any casts share the same date (need cast number to disambiguate).
+      const castDates = castKeys.map((key) => {
+        const sample = casts[key]![0]!
+        return sample.timestamp.toString().split('T')[0] ?? ''
+      })
+      const hasDuplicateDates = new Set(castDates).size < castDates.length
+
+      return castKeys.map((castKey, castIndex) => {
+        let paired = casts[castKey]!.map((sample) => ({
+          point: [sample.data[series.x], sample.data[series.y]] as [SampleValue, SampleValue],
+          source: sample,
+        })).filter(({ point: [x, y] }) => x != null && y != null)
+
+        paired = orderBy(paired, ({ point: [x] }) => x)
+        paired = uniqBy(paired, ({ point: [x, y] }) => x + '|' + y)
+
+        const firstSample = casts[castKey]![0]!
+        const rawCast = firstSample.data['Cast']
+        const castNumber = rawCast != null ? Number(rawCast) || rawCast : castIndex + 1
+        const castDate = castDates[castIndex]
+        const dateLabel = hasDuplicateDates ? `${castDate}, Cast ${castNumber}` : castDate
+        const name = baseName.replace(`(${series.year})`, `(${dateLabel})`)
+        const color = varyColor(series.color, castIndex, castKeys.length)
+
+        return {
+          original: series,
+          id: `${i}-${castIndex}`,
+          name,
+          type: series.display,
+          z: i + 2,
+          emphasis: { focus: 'series' },
+          ...({ showSymbol: series.display !== 'line' } as any),
+          data: paired.map(({ point }) => point),
+          sources: paired.map(({ source }) => source),
+          itemStyle: { color },
+          lineStyle: series.display === 'line' ? { color } : undefined,
+          xAxisLabel: series.x,
+          yAxisLabel: series.y,
+        } satisfies ChartedSeries
+      })
+    }
+
+    // Non-cast series, use single series.
+    let paired = samples
+      .map((sample) => ({
+        point: [sample.data[series.x], sample.data[series.y]] as [SampleValue, SampleValue],
+        source: sample,
+      }))
+      .filter(({ point: [x, y] }) => x != null && y != null)
+
+    let name = baseName
+    if (paired.length === 0) {
       name += ' (No Data)'
     } else {
-      // Order by the X-axis.
-      data = orderBy(data, ([x]) => x)
-      // Ensure all data points are unique.
-      data = uniqBy(data, ([x, y]) => x + '|' + y)
+      paired = orderBy(paired, ({ point: [x] }) => x)
+      paired = uniqBy(paired, ({ point: [x, y] }) => x + '|' + y)
     }
 
     return {
@@ -286,10 +358,10 @@ const chartedSeries = $computed(() => {
       z: i + 2,
       emphasis: { focus: 'series' },
       ...({ showSymbol: series.display !== 'line' } as any),
-      data,
+      data: paired.map(({ point }) => point),
+      sources: paired.map(({ source }) => source),
       itemStyle: { color: series.color },
       lineStyle: series.display === 'line' ? { color: series.color } : undefined,
-      // Not used by ECharts, stored here for tooltip rendering.
       xAxisLabel: series.x,
       yAxisLabel: series.y,
     } satisfies ChartedSeries
@@ -438,6 +510,48 @@ function isInvertedAxis(axis: string) {
   return lower.includes('depth') || lower.includes('pressure')
 }
 
+// Build axis select items from plottable fields, inserting a separator between
+// CTD Cast and non-CTD Cast fields. If the opposite axis has a CTD Cast value
+// selected, CTD Cast fields come first; otherwise non-CTD Cast fields come first.
+function axisSelectItems(series: PartialSeries, axis: 'x' | 'y') {
+  const opposite = axis === 'x' ? 'y' : 'x'
+  const oppositeValue = axis === 'x' ? series.y : series.x
+  const castFirst = typeof oppositeValue === 'string' && oppositeValue.startsWith('CTD Cast ')
+
+  const castFields: string[] = []
+  const otherFields: string[] = []
+  for (const field of discrete.plottableFields) {
+    if (field.startsWith('CTD Cast ')) {
+      castFields.push(field)
+    } else {
+      otherFields.push(field)
+    }
+  }
+
+  const ordered = castFirst ? [...castFields, ...otherFields] : [...otherFields, ...castFields]
+
+  const items: any[] = []
+  let prevWasCast: boolean | null = null
+  for (const field of ordered) {
+    const isCast = field.startsWith('CTD Cast ')
+    if (prevWasCast !== null && isCast !== prevWasCast) {
+      items.push({ type: 'separator' })
+    }
+    prevWasCast = isCast
+    items.push({
+      label:
+        `${field} ` +
+        getNoDataIndicator(
+          { asset: series.asset, [axis]: field },
+          { opposite, value: oppositeValue },
+        ),
+      value: field as string | null,
+    })
+  }
+
+  return items
+}
+
 // Invert the Y axis if depth is selected.
 const invertYAxis = $computed(() => series.every((series) => isInvertedAxis(series.y ?? '')))
 
@@ -481,25 +595,36 @@ const option = $computed(() => {
         for (const point of points) {
           const {
             seriesName,
-            seriesIndex,
+            dataIndex,
             data: [x, y],
             color,
           } = point
 
-          const series = chartedSeries[seriesIndex]
+          const series = chartedSeries.find((s) => s.name === seriesName)
           if (series == null) {
             continue
           }
+
+          const source = series.sources[dataIndex]
+          const latitude = source != null ? findFieldValue(source.data, 'latitude') : null
+          const longitude = source != null ? findFieldValue(source.data, 'longitude') : null
+          const coordinateLine =
+            latitude != null && longitude != null
+              ? '<span class="text-gray-300">' +
+                `(${formatValue(latitude, 6)}°, ${formatValue(longitude, 6)}°)` +
+                '</span><br/>'
+              : ''
 
           content.push(`
             <div>
               <div class="flex items-center mb-1">
                 <div class="w-3 h-3 rounded-full mr-1.5" style="background-color: ${color}">
               </div>
-              <b>${seriesName}</b>
+              <b>${seriesName.replace(/ — .*$/, '')}</b>
               </div>
               ${series.yAxisLabel}: <b>${formatValue(y, decimalPlacesInTooltip)}</b><br/>
               ${series.xAxisLabel}: <b>${formatValue(x, decimalPlacesInTooltip)}</b><br/>
+              ${coordinateLine}
             </div>
           `)
         }
@@ -573,6 +698,7 @@ const option = $computed(() => {
       },
     ],
     legend: {
+      data: chartedSeries.map((current) => current.name),
       selected: Object.fromEntries(
         chartedSeries.map((current) => [current.name, current.original.enabled]),
       ),
@@ -938,6 +1064,33 @@ watchEffect((onInvalidate) => {
     }
   })
 
+  // Click a data point to isolate its series, click again to restore all.
+  let isolatedSeriesName: string | null = null
+  chartInstance?.on('click', (event: any) => {
+    if (event.seriesName == null) {
+      return
+    }
+
+    if (isolatedSeriesName === event.seriesName) {
+      // Restore all series.
+      for (const series of chartedSeries) {
+        chartInstance?.dispatchAction({
+          type: 'legendSelect',
+          name: series.name,
+        })
+      }
+      isolatedSeriesName = null
+    } else {
+      // Isolate the clicked series.
+      for (const series of chartedSeries) {
+        chartInstance?.dispatchAction({
+          type: series.name === event.seriesName ? 'legendSelect' : 'legendUnSelect',
+          name: series.name,
+        })
+      }
+      isolatedSeriesName = event.seriesName
+    }
+  })
   // Keep the the series `enabled` states synced with the selected legend items of the chart.
   const legendSelectChangedEventName = 'legendselectchanged'
   chartInstance?.on(legendSelectChangedEventName, (event: any) => {
@@ -970,8 +1123,9 @@ watchEffect((onInvalidate) => {
 
   // Unregister event handlers when invalidated.
   onInvalidate(() => {
+    chartInstance?.off('click')
     chartInstance?.off(dataZoomEventName)
-    chartInstance?.off(dataZoomEventName)
+    chartInstance?.off(legendSelectChangedEventName)
   })
 })
 
@@ -1001,6 +1155,18 @@ function resetZoom() {
 }
 
 // Format a value for display in an axis label or tooltip.
+function findFieldValue(data: SampleData, substring: string): SampleValue | null {
+  // Find the first field value in sample data where the field name contains the given substring
+  // (case-insensitive).
+  const lower = substring.toLowerCase()
+  for (const [name, value] of Object.entries(data)) {
+    if (name.toLowerCase().includes(lower) && value != null) {
+      return value
+    }
+  }
+  return null
+}
+
 function formatValue(value: unknown, maxDecimalPlaces: number) {
   // The value should almost always be a number, but just in case, only try to format decimal
   // places if it is.
@@ -1447,17 +1613,7 @@ async function copyToClipboard() {
                 <u-form-field class="flex-1 min-w-80" label="X-Axis" size="sm">
                   <u-select-menu
                     class="w-full"
-                    :items="
-                      discrete.plottableFields.map((field) => ({
-                        label:
-                          `${field} ` +
-                          getNoDataIndicator(
-                            { asset: series.asset, x: field },
-                            { opposite: 'y', value: series.y },
-                          ),
-                        value: field as string | null,
-                      }))
-                    "
+                    :items="axisSelectItems(series, 'x')"
                     label-key="label"
                     :model-value="series.x ?? null"
                     size="sm"
@@ -1508,17 +1664,7 @@ async function copyToClipboard() {
                 <u-form-field class="flex-1 min-w-80" label="Y-Axis" size="sm">
                   <u-select-menu
                     class="w-full"
-                    :items="
-                      discrete.plottableFields.map((field) => ({
-                        label:
-                          `${field} ` +
-                          getNoDataIndicator(
-                            { asset: series.asset, y: field },
-                            { opposite: 'x', value: series.x },
-                          ),
-                        value: field ?? null,
-                      }))
-                    "
+                    :items="axisSelectItems(series, 'y')"
                     label-key="label"
                     :model-value="series.y"
                     size="sm"
@@ -1551,7 +1697,21 @@ async function copyToClipboard() {
                   </u-select-menu>
                 </u-form-field>
                 <div class="flex flex-1 flex-row shrink space-x-2">
-                  <u-form-field class="basis-0 grow min-w-34" label="Year" size="sm">
+                  <u-form-field class="basis-0 grow min-w-24" label="Year" size="sm">
+                    <template #hint>
+                      <u-tooltip text="Show separate chart-series for each CTD cast collected.">
+                        <u-checkbox
+                          class="flex-row-reverse gap-1 items-center"
+                          label="Show Casts"
+                          :model-value="series.showCasts ?? false"
+                          size="xs"
+                          :ui="{ label: 'text-[11px]' }"
+                          @update:model-value="
+                            (value) => setSeriesField(i, 'showCasts', value && true)
+                          "
+                        />
+                      </u-tooltip>
+                    </template>
                     <u-select-menu
                       :key="series.year"
                       class="w-full"

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -170,14 +170,19 @@ const series = $computed(
 const xAxesAreSame = $computed(() => uniq(compact(series.map((series) => series.x))).length <= 1)
 // True if all series share the same Y axis value.
 const yAxesAreSame = $computed(() => uniq(compact(series.map((series) => series.y))).length <= 1)
-// True if all series share the same X and Y axis values.
-const allAxesAreSame = $computed(() => xAxesAreSame && yAxesAreSame)
 
-// Cache for `getSamplesFor` below.
-const getSamplesForCache: Record<string, Sample[]> = {}
+// Cache for `getSamplesFor` below, invalidated when discrete samples change.
+let getSamplesForCache: Record<string, Sample[]> = {}
+let getSamplesForCacheSource: readonly Sample[] = []
 
 // Return all samples matching the provided filter.
 function getSamplesFor(filter: SampleFilter): Sample[] {
+  // Invalidate cache when the underlying samples change.
+  if (discrete.samples !== getSamplesForCacheSource) {
+    getSamplesForCache = {}
+    getSamplesForCacheSource = discrete.samples
+  }
+
   const key = [filter.asset ?? '-', filter.x ?? '-', filter.y ?? '-', filter.year ?? '-'].join('&&')
 
   const cached = getSamplesForCache[key]
@@ -264,23 +269,80 @@ function varyColor(baseColor: string, index: number, length: number): string {
     .hex()
 }
 
+// Per-entry legend selection overrides for cast sub-series that have been individually toggled.
+const legendSelectionOverrides = reactive(new Map<string, boolean>())
+
+// A plottable data point with its source sample.
+type DataPoint = {
+  x: SampleValue
+  y: SampleValue
+  source: Sample
+}
+
+// Extract x/y values from samples into data points, filter out nulls, sort by x, and dedupe.
+function extractDataPoints(
+  samples: Sample[],
+  x: string | undefined,
+  y: string | undefined,
+): DataPoint[] {
+  let points = samples
+    .map((sample) => ({
+      x: sample.data[x!] ?? null,
+      y: sample.data[y!] ?? null,
+      source: sample,
+    }))
+    .filter((point) => point.x != null && point.y != null)
+
+  points = orderBy(points, (point) => point.x)
+  points = uniqBy(points, (point) => point.x + '|' + point.y)
+  return points
+}
+
+function createChartedSeries(
+  series: Series,
+  id: string | number,
+  index: number,
+  name: string,
+  color: string,
+  points: DataPoint[],
+): ChartedSeries {
+  const castSeries = isCTDCastSeries(series)
+  return {
+    original: series,
+    id,
+    name,
+    type: series.display,
+    z: index + 2,
+    emphasis: { focus: 'series' },
+    ...({
+      showSymbol: series.display !== 'line' || !castSeries,
+      ...(castSeries ? { symbolSize: 8 } : {}),
+    } as any),
+    data: points.map((point) => [point.x, point.y]),
+    sources: points.map((point) => point.source),
+    itemStyle: { color },
+    lineStyle: series.display === 'line' ? { color } : undefined,
+    xAxisLabel: series.x,
+    yAxisLabel: series.y,
+  }
+}
+
 // Computed ECharts series options with data points.
 const chartedSeries = $computed(() => {
   return series.flatMap((series, i) => {
     const samples = getSamplesFor(series)
 
-    // We need to create unique series names depending on which axes are the same/different.
-    let baseName: string
-    if (allAxesAreSame) {
-      baseName = `${series.asset} (${series.year})`
-    } else if (xAxesAreSame) {
-      baseName = `${series.asset} (${series.year}) — ${series.y}`
-    } else if (yAxesAreSame) {
-      baseName = `${series.asset} (${series.year}) — ${series.x}`
-    } else {
-      baseName = `${series.asset} (${series.year}) — ${series.y} / ${series.x}`
+    // Build unique series names depending on which axes are the same/different.
+    let baseName = `${series.asset} (${series.year})`
+    if (!xAxesAreSame && !yAxesAreSame) {
+      baseName += ` — ${series.y} / ${series.x}`
+    } else if (!xAxesAreSame) {
+      baseName += ` — ${series.x}`
+    } else if (!yAxesAreSame) {
+      baseName += ` — ${series.y}`
     }
 
+    // Split into per-cast series when enabled and cast data is available.
     const castSamples = series.showCasts
       ? samples.filter((sample) => sample.data['Cast'] != null)
       : []
@@ -299,14 +361,7 @@ const chartedSeries = $computed(() => {
       const hasDuplicateDates = new Set(castDates).size < castDates.length
 
       return castKeys.map((castKey, castIndex) => {
-        let paired = casts[castKey]!.map((sample) => ({
-          point: [sample.data[series.x], sample.data[series.y]] as [SampleValue, SampleValue],
-          source: sample,
-        })).filter(({ point: [x, y] }) => x != null && y != null)
-
-        paired = orderBy(paired, ({ point: [x] }) => x)
-        paired = uniqBy(paired, ({ point: [x, y] }) => x + '|' + y)
-
+        const points = extractDataPoints(casts[castKey]!, series.x, series.y)
         const firstSample = casts[castKey]![0]!
         const rawCast = firstSample.data['Cast']
         const castNumber = rawCast != null ? Number(rawCast) || rawCast : castIndex + 1
@@ -315,59 +370,22 @@ const chartedSeries = $computed(() => {
         const name = baseName.replace(`(${series.year})`, `(${dateLabel})`)
         const color = varyColor(series.color, castIndex, castKeys.length)
 
-        return {
-          original: series,
-          id: `${i}-${castIndex}`,
-          name,
-          type: series.display,
-          z: i + 2,
-          emphasis: { focus: 'series' },
-          ...({
-            showSymbol: series.display !== 'line' || !isCTDCastSeries(series),
-          } as any),
-          data: paired.map(({ point }) => point),
-          sources: paired.map(({ source }) => source),
-          itemStyle: { color },
-          lineStyle: series.display === 'line' ? { color } : undefined,
-          xAxisLabel: series.x,
-          yAxisLabel: series.y,
-        } satisfies ChartedSeries
+        return createChartedSeries(series, `${i}-${castIndex}`, i, name, color, points)
       })
     }
 
-    // Non-cast series, use single series.
-    let paired = samples
-      .map((sample) => ({
-        point: [sample.data[series.x], sample.data[series.y]] as [SampleValue, SampleValue],
-        source: sample,
-      }))
-      .filter(({ point: [x, y] }) => x != null && y != null)
+    const points = extractDataPoints(samples, series.x, series.y)
+    const name = points.length === 0 ? baseName + ' (No Data)' : baseName
 
-    let name = baseName
-    if (paired.length === 0) {
-      name += ' (No Data)'
-    } else {
-      paired = orderBy(paired, ({ point: [x] }) => x)
-      paired = uniqBy(paired, ({ point: [x, y] }) => x + '|' + y)
-    }
-
-    return {
-      original: series,
-      id: i,
-      name,
-      type: series.display,
-      z: i + 2,
-      emphasis: { focus: 'series' },
-      ...({ showSymbol: series.display !== 'line' } as any),
-      data: paired.map(({ point }) => point),
-      sources: paired.map(({ source }) => source),
-      itemStyle: { color: series.color },
-      lineStyle: series.display === 'line' ? { color: series.color } : undefined,
-      xAxisLabel: series.x,
-      yAxisLabel: series.y,
-    } satisfies ChartedSeries
+    return createChartedSeries(series, i, i, name, series.color, points)
   })
 })
+
+// Clear stale legend overrides when the set of charted series names changes.
+watch(
+  () => chartedSeries.map((charted) => charted.name).join('\0'),
+  () => legendSelectionOverrides.clear(),
+)
 
 // Calculate R-squared value for correlation analysis.
 function calculateRSquared(datasets: [SampleValue, SampleValue][][]) {
@@ -600,7 +618,7 @@ const option = $computed(() => {
       trigger: 'axis',
       // Show both axis values for all hovered points.
       formatter: (points: any) => {
-        const content = ['<div class="space-y-2">']
+        const sections: string[] = []
         for (const point of points) {
           const {
             seriesName,
@@ -617,30 +635,43 @@ const option = $computed(() => {
           const source = series.sources[dataIndex]
           const latitude = source != null ? findFieldValue(source.data, 'latitude') : null
           const longitude = source != null ? findFieldValue(source.data, 'longitude') : null
-          const coordinateLine =
-            latitude != null && longitude != null
-              ? '<span class="text-gray-500">Cast Location</span> ' +
-                '<span class="text-gray-400">' +
-                `(${formatValue(latitude, 6)}°, ${formatValue(longitude, 6)}°)` +
-                '</span><br/>'
-              : ''
 
-          content.push(`
-            <div>
-              <div class="flex items-center mb-1">
-                <div class="w-3 h-3 rounded-full mr-1.5" style="background-color: ${color}">
-              </div>
-              <b>${seriesName.replace(/ — .*$/, '')}</b>
-              </div>
-              ${series.yAxisLabel}: <b>${formatValue(y, decimalPlacesInTooltip)}</b><br/>
-              ${series.xAxisLabel}: <b>${formatValue(x, decimalPlacesInTooltip)}</b><br/>
-              ${coordinateLine}
-            </div>
-          `)
+          const rows: string[] = []
+          rows.push(
+            `<tr>` +
+              `<td class="text-right text-gray-500 pr-2">${series.yAxisLabel}</td>` +
+              `<td class="font-bold">${formatValue(y, decimalPlacesInTooltip)}</td>` +
+              `</tr>`,
+          )
+          rows.push(
+            `<tr>` +
+              `<td class="text-right text-gray-500 pr-2">${series.xAxisLabel}</td>` +
+              `<td class="font-bold">${formatValue(x, decimalPlacesInTooltip)}</td>` +
+              `</tr>`,
+          )
+          if (latitude != null && longitude != null) {
+            rows.push(
+              `<tr>` +
+                `<td class="text-right text-gray-500 pr-2">Location</td>` +
+                `<td class="text-gray-500">` +
+                `(${formatValue(latitude, 6)}°, ${formatValue(longitude, 6)}°)` +
+                `</td>` +
+                `</tr>`,
+            )
+          }
+
+          sections.push(
+            `<div>` +
+              `<div class="flex items-center mb-1">` +
+              `<div class="w-3 h-3 rounded-full mr-1.5" style="background-color: ${color}"></div>` +
+              `<b>${seriesName.replace(/ — .*$/, '')}</b>` +
+              `</div>` +
+              `<table class="[&_td+td]:border-l [&_td+td]:border-gray-700 [&_td+td]:pl-2">${rows.join('')}</table>` +
+              `</div>`,
+          )
         }
 
-        content.push('</div>')
-        return content.join('')
+        return `<div class="space-y-2">${sections.join('')}</div>`
       },
     },
     xAxis: {
@@ -710,7 +741,10 @@ const option = $computed(() => {
     legend: {
       data: chartedSeries.map((current) => current.name),
       selected: Object.fromEntries(
-        chartedSeries.map((current) => [current.name, current.original.enabled]),
+        chartedSeries.map((current) => [
+          current.name,
+          legendSelectionOverrides.get(current.name) ?? current.original.enabled,
+        ]),
       ),
       show: chartedSeries.length <= 20,
       type: 'scroll',
@@ -1100,34 +1134,55 @@ watchEffect((onInvalidate) => {
       isolatedSeriesName = event.seriesName
     }
   })
-  // Keep the the series `enabled` states synced with the selected legend items of the chart.
+  // Keep the series `enabled` states synced with the selected legend items of the chart.
   const legendSelectChangedEventName = 'legendselectchanged'
   chartInstance?.on(legendSelectChangedEventName, (event: any) => {
     const selected: Record<string, boolean> | undefined = event.selected
-    if (selected == null) {
+    const clickedName: string | undefined = event.name
+    if (selected == null || clickedName == null) {
       return
     }
 
-    const currentSelectedStates = Object.values(selected)
-    const previousSelectedStates = state.series.map((series) => series.enabled)
+    console.debug('Series selection changed from legend.', clickedName, selected)
 
-    console.debug('Series selection changed from legend.', selected)
-    for (const [i, isSelected] of currentSelectedStates.entries()) {
-      const previousIsSelected = previousSelectedStates[i]
-      if (isSelected !== previousIsSelected) {
-        setSeriesField(i, 'enabled', isSelected)
-        return
-      }
+    const clicked = chartedSeries.find((charted) => charted.name === clickedName)
+    if (clicked == null) {
+      return
     }
 
-    for (const [i, isSelected] of Object.values(selected).entries()) {
-      const series = state.series[i]
-      if (series != null) {
-        series.enabled = isSelected
+    const isSelected = selected[clickedName] ?? true
+    const group = chartedSeries.filter((charted) => charted.original === clicked.original)
+    const seriesIndex = series.indexOf(clicked.original)
+
+    // When shift is held, toggle all series in the same original group together.
+    if (isShiftPressed) {
+      for (const charted of group) {
+        legendSelectionOverrides.set(charted.name, isSelected)
       }
+      if (seriesIndex !== -1 && state.series[seriesIndex]!.enabled !== isSelected) {
+        setSeriesField(seriesIndex, 'enabled', isSelected)
+      }
+      return
     }
 
-    history.save()
+    // Store the override for the individual legend entry.
+    legendSelectionOverrides.set(clickedName, isSelected)
+
+    // Sync the parent `enabled` state when all sub-series in the group agree.
+    if (seriesIndex !== -1) {
+      const allSelected = group.every(
+        (charted) => legendSelectionOverrides.get(charted.name) ?? charted.original.enabled,
+      )
+      const noneSelected = group.every(
+        (charted) => !(legendSelectionOverrides.get(charted.name) ?? charted.original.enabled),
+      )
+
+      if (noneSelected && state.series[seriesIndex]!.enabled) {
+        setSeriesField(seriesIndex, 'enabled', false)
+      } else if (allSelected && !state.series[seriesIndex]!.enabled) {
+        setSeriesField(seriesIndex, 'enabled', true)
+      }
+    }
   })
 
   // Unregister event handlers when invalidated.

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -81,6 +81,10 @@ const SeriesSchema = Zod.object({
   enabled: Zod.boolean().default(true),
   showCasts: Zod.boolean().default(false).catch(false),
   color: Zod.string().default(chartColors[0]),
+  // Internal ID for tracking series identity. Last so it appears at the end of the URL.
+  id: Zod.string()
+    .default(() => crypto.randomUUID())
+    .catch(() => crypto.randomUUID()),
 })
 
 function createDefaultZoom(): ZoomState {
@@ -127,6 +131,9 @@ const ctrlKey = isMac ? 'Command' : 'Ctrl'
 // Omit `zoom` and any other other unintuitive visual-related changes from undo/redo history.
 const historyOmit: ReadonlyArray<keyof typeof state> = ['zoom', 'seriesCollapsed']
 // Implement undo/redo for modifying the page's state.
+// Internal IDs for tracking series identity. Not persisted to the URL. Stored as a non-enumerable
+// property directly on each series object so it survives reactive proxy wrapping and spread copies
+// won't include it.
 const history = useUndo({
   current: () => state,
   onUndo(values) {
@@ -297,7 +304,7 @@ function extractDataPoints(
 
 function createChartedSeries(
   series: Series,
-  id: string | number,
+  id: string,
   index: number,
   name: string,
   color: string,
@@ -371,14 +378,14 @@ const chartedSeries = $computed(() => {
         const name = baseName.replace(`(${series.year})`, `(${dateLabel})`)
         const color = varyColor(series.color, castIndex, castKeys.length)
 
-        return createChartedSeries(series, `${i}-${castIndex}`, i, name, color, points)
+        return createChartedSeries(series, `${series.id}-${castIndex}`, i, name, color, points)
       })
     }
 
     const points = extractDataPoints(samples, series.x, series.y)
     const name = points.length === 0 ? baseName + ' (No Data)' : baseName
 
-    return createChartedSeries(series, i, i, name, series.color, points)
+    return createChartedSeries(series, series.id, i, name, series.color, points)
   })
 })
 
@@ -528,19 +535,6 @@ const yAxisMinMax = $computed(() => getAxisMinMax('y'))
 function isInvertedAxis(axis: string) {
   const lower = axis.toLowerCase()
   return lower.includes('depth') || lower.includes('pressure')
-}
-
-// Compare two series-like objects by their identifying fields rather than reference.
-function sameOriginal(
-  left: { asset?: string; x?: string; y?: string; year?: number },
-  right: { asset?: string; x?: string; y?: string; year?: number },
-): boolean {
-  return (
-    left.asset === right.asset &&
-    left.x === right.x &&
-    left.y === right.y &&
-    left.year === right.year
-  )
 }
 
 function isCTDCastField(field: string | undefined): boolean {
@@ -943,7 +937,7 @@ function setSeriesField<K extends keyof PartialSeries>(
     const target = state.series[index]
     if (target != null) {
       for (const charted of chartedSeries) {
-        if (sameOriginal(charted.original, target)) {
+        if (charted.original.id === target.id) {
           legendSelectionOverrides.delete(charted.name)
         }
       }
@@ -1178,10 +1172,8 @@ watchEffect((onInvalidate) => {
     }
 
     const isSelected = selected[clickedName] ?? true
-    const group = chartedSeries.filter((charted) =>
-      sameOriginal(charted.original, clicked.original),
-    )
-    const seriesIndex = state.series.findIndex((current) => sameOriginal(clicked.original, current))
+    const group = chartedSeries.filter((charted) => charted.original.id === clicked.original.id)
+    const seriesIndex = state.series.findIndex((current) => current.id === clicked.original.id)
     const series = seriesIndex !== -1 ? state.series[seriesIndex]! : null
 
     // When shift is held, toggle all series in the same original group together.

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -75,7 +75,6 @@ const SeriesSchema = Zod.object({
   // `undefined` as being "no input" instead of an actual value, despite accepting them
   // type-checking wise. This ends up causing weird behavior where the value in the state goes out
   // of sync with the value stored/displayed by the component in some cases.
-  station: Zod.string().optional(),
   asset: Zod.string().optional(),
   x: Zod.string().optional(),
   y: Zod.string().optional(),
@@ -144,7 +143,7 @@ type PartialSeries = (typeof state)['series'][number]
 // Fully defined series with included index.
 type Series = Required<PartialSeries>
 // Fields in series objects used for filtering samples.
-type SampleFilter = Pick<PartialSeries, 'station' | 'asset' | 'x' | 'y' | 'year'>
+type SampleFilter = Pick<PartialSeries, 'asset' | 'x' | 'y' | 'year'>
 
 // Assets that can be selected for plotting, with CTD Cast assets sorted last.
 const selectableAssets = $computed(() => {
@@ -194,13 +193,7 @@ const getSamplesForCache: Record<string, Sample[]> = {}
 
 // Return all samples matching the provided filter.
 function getSamplesFor(filter: SampleFilter): Sample[] {
-  const key = [
-    filter.station ?? '-',
-    filter.asset ?? '-',
-    filter.x ?? '-',
-    filter.y ?? '-',
-    filter.year ?? '-',
-  ].join('&&')
+  const key = [filter.asset ?? '-', filter.x ?? '-', filter.y ?? '-', filter.year ?? '-'].join('&&')
 
   const cached = getSamplesForCache[key]
   if (cached != null) {
@@ -209,7 +202,6 @@ function getSamplesFor(filter: SampleFilter): Sample[] {
 
   const samples = discrete.samples.filter(
     (sample) =>
-      (filter.station == null || sample.station === filter.station) &&
       (filter.asset == null || sample.asset === filter.asset) &&
       (filter.x == null || sample.data[filter.x!] != null) &&
       (filter.y == null || sample.data[filter.y!] != null) &&

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -38,7 +38,6 @@ const chartInstance = $ref<InstanceType<typeof Chart> | null>(null)
 
 // Load discrete data.
 const discrete = useDiscrete()
-await discrete.load()
 
 // Pre-defined colors for new series when first inserted.
 const chartColors = [
@@ -1260,7 +1259,11 @@ async function copyToClipboard() {
   <u-page>
     <u-page-body class="mb-24 px-8 space-y-4">
       <u-page-header title="Discrete Data" />
-      <div>
+      <div v-if="discrete.loading" class="flex flex-col items-center justify-center py-32">
+        <u-icon class="animate-spin text-4xl text-primary" name="i-lucide-loader-2" />
+        <p class="mt-4 text-gray-500">Loading discrete samples...</p>
+      </div>
+      <div v-else>
         <div v-if="option != null" class="relative">
           <chart ref="chartInstance" class="min-h-150" :option="option" />
           <u-tooltip

--- a/dashboard/app/components/pages/DiscretePage.vue
+++ b/dashboard/app/components/pages/DiscretePage.vue
@@ -75,6 +75,7 @@ const SeriesSchema = Zod.object({
   // `undefined` as being "no input" instead of an actual value, despite accepting them
   // type-checking wise. This ends up causing weird behavior where the value in the state goes out
   // of sync with the value stored/displayed by the component in some cases.
+  station: Zod.string().optional(),
   asset: Zod.string().optional(),
   x: Zod.string().optional(),
   y: Zod.string().optional(),
@@ -143,10 +144,28 @@ type PartialSeries = (typeof state)['series'][number]
 // Fully defined series with included index.
 type Series = Required<PartialSeries>
 // Fields in series objects used for filtering samples.
-type SampleFilter = Pick<PartialSeries, 'asset' | 'x' | 'y' | 'year'>
+type SampleFilter = Pick<PartialSeries, 'station' | 'asset' | 'x' | 'y' | 'year'>
 
-// Assets that can be selected for plotting.
-const selectableAssets = $computed(() => discrete.assets.filter((asset) => asset !== 'PI_REQUEST'))
+// Assets that can be selected for plotting, with CTD Cast assets sorted last.
+const selectableAssets = $computed(() => {
+  const assets = compact(discrete.assets.filter((asset) => asset !== 'PI_REQUEST'))
+  return orderBy(assets, [(asset) => (getAssetGroup(asset) === 'ctd-cast' ? 1 : 0)])
+})
+
+function getAssetGroup(asset: string): 'normal' | 'ctd-cast' {
+  if (asset.startsWith('CTD Cast (')) {
+    return 'ctd-cast'
+  }
+  return 'normal'
+}
+
+// Return the subset of selectable assets that belong to the same group (CTD Cast or non-CTD Cast)
+// as the given asset. Used when duplicating a series for all assets of the same kind. If the asset
+// is `null` or `undefined`, return all "normal" assets.
+function peerAssetsFor(asset: string | null | undefined): string[] {
+  const group = asset != null ? getAssetGroup(asset) : 'normal'
+  return selectableAssets.filter((asset) => getAssetGroup(asset) === group)
+}
 
 // All series with filter fields completely filled out.
 const series = $computed(
@@ -175,7 +194,14 @@ const getSamplesForCache: Record<string, Sample[]> = {}
 
 // Return all samples matching the provided filter.
 function getSamplesFor(filter: SampleFilter): Sample[] {
-  const key = [filter.asset ?? '-', filter.x ?? '-', filter.y ?? '-', filter.year ?? '-'].join('&&')
+  const key = [
+    filter.station ?? '-',
+    filter.asset ?? '-',
+    filter.x ?? '-',
+    filter.y ?? '-',
+    filter.year ?? '-',
+  ].join('&&')
+
   const cached = getSamplesForCache[key]
   if (cached != null) {
     return cached
@@ -183,6 +209,7 @@ function getSamplesFor(filter: SampleFilter): Sample[] {
 
   const samples = discrete.samples.filter(
     (sample) =>
+      (filter.station == null || sample.station === filter.station) &&
       (filter.asset == null || sample.asset === filter.asset) &&
       (filter.x == null || sample.data[filter.x!] != null) &&
       (filter.y == null || sample.data[filter.y!] != null) &&
@@ -452,7 +479,7 @@ const option = $computed(() => {
       top: '24px',
       left: '0',
       right: '32px',
-      bottom: '140px',
+      bottom: '100px',
     },
     tooltip: {
       confine: true,
@@ -535,7 +562,7 @@ const option = $computed(() => {
       {
         id: 'x-slider',
         type: 'slider',
-        bottom: 80,
+        bottom: 48,
         height: 22,
         showDetail: false,
         showDataShadow: false,
@@ -556,6 +583,7 @@ const option = $computed(() => {
         chartedSeries.map((current) => [current.name, current.original.enabled]),
       ),
       show: chartedSeries.length <= 20,
+      type: 'scroll',
       bottom: 0,
     },
     series: chartedSeries as any,
@@ -622,6 +650,16 @@ function removeSeries(index?: number) {
   history.save(state)
 
   return removed
+}
+
+function removeOtherSeries(index: number) {
+  const series = state.series[index]
+  if (series == null) {
+    return
+  }
+
+  state.series = [series]
+  history.save(state)
 }
 
 // Move the series at the given index up one position, if possible.
@@ -829,10 +867,11 @@ function duplicateSeriesForAllAssets(
     return
   }
 
+  const peers = peerAssetsFor(series.asset)
   let assetsToGenerate = withMatchingData
     ? // All assets for which we have data matching the series' `x`, `y`, and `year`.
-      selectableAssets.filter((current) => hasDataFor({ ...series, asset: current }))
-    : selectableAssets
+      peers.filter((current) => hasDataFor({ ...series, asset: current }))
+    : peers
 
   if (series.asset != null) {
     // If the original series has an `asset` set and it's in the list, we don't need to generate it.
@@ -1053,98 +1092,101 @@ async function copyToClipboard() {
     <u-page-body class="mb-24 px-8 space-y-4">
       <u-page-header title="Discrete Data" />
       <div>
-        <div v-if="option != null" class="pb-10">
-          <div class="relative">
-            <chart ref="chartInstance" class="h-150" :option="option" />
-            <div class="-bottom-12 absolute flex justify-center left-0 right-0 space-x-2">
-              <u-form-field class="flex items-center" size="sm">
-                <template #label><div class="pt-1 text-xs">Bounds =</div></template>
-                <u-tooltip
-                  text="Choose how the min and max values on the X and Y axes are calculated."
-                >
-                  <u-select
-                    v-model="state.bounds"
-                    class="min-w-50 ml-1"
-                    :items="[
-                      { label: 'Selected Data Min/Max', value: 'selected-data' },
-                      { label: 'Data Min/Max', value: 'all-data' },
-                      { label: 'From Zero', value: 'from-zero' },
-                      { label: 'From Zero (X)', value: 'from-zero-x' },
-                      { label: 'From Zero (Y)', value: 'from-zero-y' },
-                    ]"
-                    size="sm"
-                    @update:model-value="history.save(state)"
-                  />
-                </u-tooltip>
-              </u-form-field>
-              <u-tooltip text="Reset Zoom">
-                <u-button
-                  class="mt-1"
-                  color="primary"
-                  :disabled="!isZoomedIn"
-                  icon="i-lucide-zoom-out"
-                  label="Reset"
-                  size="xs"
-                  variant="subtle"
-                  @click="resetZoom"
-                />
-              </u-tooltip>
-              <u-tooltip text="Swap X and Y Axes">
-                <u-button
-                  class="mt-1"
-                  color="primary"
-                  :disabled="state.series.length === 0"
-                  size="xs"
-                  variant="subtle"
-                  @click="
-                    () => {
-                      for (const series of state.series) {
-                        const { x, y } = series
-                        series.x = y
-                        series.y = x
-                      }
-
-                      history.save(state)
-                    }
-                  "
-                >
-                  X <u-icon name="i-lucide-arrow-left-right" /> Y
-                </u-button>
-              </u-tooltip>
-              <u-tooltip text="Share Plot Link">
-                <u-button
-                  class="cursor-pointer mt-1 px-2"
-                  :disabled="!canShare"
-                  icon="i-lucide-share"
-                  size="xs"
-                  variant="subtle"
-                  @click="share()"
-                />
-              </u-tooltip>
-              <u-tooltip text="Copy Plot Link to Clipboard">
-                <u-button
-                  class="cursor-pointer mt-1 px-2"
-                  icon="i-lucide-link"
-                  size="xs"
-                  variant="subtle"
-                  @click="copyToClipboard()"
-                />
-              </u-tooltip>
+        <div v-if="option != null" class="relative">
+          <chart ref="chartInstance" class="min-h-150" :option="option" />
+          <u-tooltip
+            v-if="rSquared != null"
+            class="absolute cursor-default right-8 top-0.75"
+            text="The R-squared value for all currently selected data."
+          >
+            <div
+              class="text-[12.5px] text-center text-gray-600"
+              style="font-family: 'Helvetica Neue', 'Helvetica'"
+            >
+              <span class="mr-1.5 relative">
+                R
+                <span class="-right-0.5 -top-0.5 absolute text-[10px]">2</span>
+              </span>
+              = {{ formatValue(rSquared, 6) }}
             </div>
-            <u-tooltip text="The R-squared value for all currently selected data.">
-              <div>
-                <div v-if="rSquared != null" class="mt-3 text-[14px] text-center">
-                  <span class="mr-1 relative">
-                    R
-                    <span class="-right-0.5 -top-0.5 absolute text-[10px]">2</span>
-                  </span>
-                  = {{ formatValue(rSquared, 6) }}
-                </div>
-              </div>
+          </u-tooltip>
+          <div class="flex justify-center mb-4 mt-4 space-x-2">
+            <u-form-field class="flex items-center" size="sm">
+              <template #label><div class="text-nowrap text-xs">Bounds =</div></template>
+              <u-tooltip
+                text="Choose how the min and max values on the X and Y axes are calculated."
+              >
+                <u-select
+                  v-model="state.bounds"
+                  class="min-w-50 ml-1"
+                  :items="[
+                    { label: 'Selected Data Min/Max', value: 'selected-data' },
+                    { label: 'Data Min/Max', value: 'all-data' },
+                    { label: 'From Zero', value: 'from-zero' },
+                    { label: 'From Zero (X)', value: 'from-zero-x' },
+                    { label: 'From Zero (Y)', value: 'from-zero-y' },
+                  ]"
+                  size="sm"
+                  @update:model-value="history.save(state)"
+                />
+              </u-tooltip>
+            </u-form-field>
+            <u-tooltip text="Reset Zoom">
+              <u-button
+                class="mt-1"
+                color="primary"
+                :disabled="!isZoomedIn"
+                icon="i-lucide-zoom-out"
+                label="Reset"
+                size="xs"
+                variant="subtle"
+                @click="resetZoom"
+              />
+            </u-tooltip>
+            <u-tooltip text="Swap X and Y Axes">
+              <u-button
+                class="mt-1"
+                color="primary"
+                :disabled="state.series.length === 0"
+                size="xs"
+                variant="subtle"
+                @click="
+                  () => {
+                    for (const series of state.series) {
+                      const { x, y } = series
+                      series.x = y
+                      series.y = x
+                    }
+
+                    history.save(state)
+                  }
+                "
+              >
+                X <u-icon name="i-lucide-arrow-left-right" /> Y
+              </u-button>
+            </u-tooltip>
+            <u-tooltip text="Share Plot Link">
+              <u-button
+                class="cursor-pointer mt-1 px-2"
+                :disabled="!canShare"
+                icon="i-lucide-share"
+                size="xs"
+                variant="subtle"
+                @click="share()"
+              />
+            </u-tooltip>
+            <u-tooltip text="Copy Plot Link to Clipboard">
+              <u-button
+                class="cursor-pointer mt-1 px-2"
+                icon="i-lucide-link"
+                size="xs"
+                variant="subtle"
+                @click="copyToClipboard()"
+              />
             </u-tooltip>
           </div>
         </div>
-        <p v-else class="opacity-80 text-center text-sm">
+        <p v-else class="mb-2 opacity-80 text-center text-sm">
           <template v-if="state.series.length > 0">
             Enter the asset, X/Y axis and year of data to plot.
           </template>
@@ -1323,6 +1365,18 @@ async function copyToClipboard() {
                           },
                           { type: 'separator' },
                           {
+                            icon: 'i-lucide-trash-2',
+                            label: 'Remove',
+                            onSelect: () => removeSeries(i),
+                          },
+                          {
+                            icon: 'i-lucide-brush-cleaning',
+                            label: 'Remove Other Series',
+                            disabled: state.series.length < 2,
+                            onSelect: () => removeOtherSeries(i),
+                          },
+                          { type: 'separator' },
+                          {
                             icon: 'i-lucide-square-stack',
                             label: `Duplicate For All Years (${possibleYears.length})`,
                             onSelect: () =>
@@ -1344,7 +1398,9 @@ async function copyToClipboard() {
                           { type: 'separator' },
                           {
                             icon: 'i-lucide-square-stack',
-                            label: `Duplicate For All Assets (${discrete.assets.length})`,
+                            label:
+                              'Duplicate For All Assets ' +
+                              `(${peerAssetsFor(series.asset).length})`,
                             onSelect: () =>
                               duplicateSeriesForAllAssets(i, { withMatchingData: false }),
                           },
@@ -1353,9 +1409,11 @@ async function copyToClipboard() {
                             label:
                               'Duplicate For All Assets With Matching Data (' +
                               uniq(
-                                getSamplesFor(omit(series, ['asset'])).map(
-                                  (current) => current.asset,
-                                ),
+                                getSamplesFor(omit(series, ['asset']))
+                                  .map((current) => current.asset)
+                                  .filter((asset) =>
+                                    peerAssetsFor(series.asset).includes(asset ?? ''),
+                                  ),
                               ).length +
                               ')',
                             onSelect: () =>
@@ -1379,7 +1437,9 @@ async function copyToClipboard() {
                     :items="[
                       ...selectableAssets.map((asset) => ({
                         label:
-                          `${asset} (${discrete.assetToStation[asset]})` +
+                          (asset.includes('(')
+                            ? asset
+                            : `${asset} (${discrete.assetToStation[asset]})`) +
                           `${getNoDataIndicator({ asset })}`,
                         value: asset as string | null,
                       })),

--- a/dashboard/app/components/pages/Event.vue
+++ b/dashboard/app/components/pages/Event.vue
@@ -308,69 +308,67 @@ function downloadPDF() {
 <template>
   <div class="image-report-root p-6">
     <!-- Page header (hidden when printing) -->
-    <div class="no-print flex items-center justify-between mb-6">
-      <div class="flex items-center gap-2">
-        <h1 class="font-bold text-2xl mr-3">Event Report</h1>
-        <div class="flex flex-col items-center gap-1">
-          <u-button
-            class="text-4xl"
-            @click="loadPreset(PRESET_TSUNAMI, presetTimespans.tsunami)"
+    <div class="flex items-center justify-between mb-6 no-print">
+      <div class="flex gap-2 items-center">
+        <h1 class="font-bold mr-3 text-2xl">Event Report</h1>
+        <div class="flex flex-col gap-1 items-center">
+          <u-button class="text-4xl" @click="loadPreset(PRESET_TSUNAMI, presetTimespans.tsunami)"
             >🌊</u-button
           >
           <u-select-menu
             v-model="presetTimespans.tsunami"
+            class="text-xs w-24"
             :items="timeSpans"
-            value-key="key"
             multiple
-            class="w-24 text-xs"
+            value-key="key"
           />
         </div>
-        <div class="flex flex-col items-center gap-1">
+        <div class="flex flex-col gap-1 items-center">
           <u-button
-            variant="ghost"
-            size="lg"
             class="text-4xl"
+            size="lg"
+            variant="ghost"
             @click="loadPreset(PRESET_EARTHQUAKE, presetTimespans.earthquake)"
             >🌍</u-button
           >
           <u-select-menu
             v-model="presetTimespans.earthquake"
+            class="text-xs w-24"
             :items="timeSpans"
-            value-key="key"
             multiple
-            class="w-24 text-xs"
+            value-key="key"
           />
         </div>
-        <div class="flex flex-col items-center gap-1">
+        <div class="flex flex-col gap-1 items-center">
           <u-button
-            variant="ghost"
-            size="lg"
             class="text-4xl"
+            size="lg"
+            variant="ghost"
             @click="loadPreset(PRESET_VOLCANO, presetTimespans.volcano)"
             >🌋</u-button
           >
           <u-select-menu
             v-model="presetTimespans.volcano"
+            class="text-xs w-24"
             :items="timeSpans"
-            value-key="key"
             multiple
-            class="w-24 text-xs"
+            value-key="key"
           />
         </div>
-        <div class="flex flex-col items-center gap-1">
+        <div class="flex flex-col gap-1 items-center">
           <u-button
-            variant="ghost"
-            size="lg"
             class="text-4xl"
+            size="lg"
+            variant="ghost"
             @click="loadPreset(PRESET_MARINE_HEATWAVE, presetTimespans.marineHeatwave)"
             >🌡️</u-button
           >
           <u-select-menu
             v-model="presetTimespans.marineHeatwave"
+            class="text-xs w-24"
             :items="timeSpans"
-            value-key="key"
             multiple
-            class="w-24 text-xs"
+            value-key="key"
           />
         </div>
       </div>
@@ -379,9 +377,9 @@ function downloadPDF() {
       </u-button>
     </div>
 
-    <div class="no-print h-px bg-gray-200 mb-6" />
+    <div class="bg-gray-200 h-px mb-6 no-print" />
 
-    <div v-if="isLoading" class="no-print text-gray-500 py-8 text-center">Loading plot list…</div>
+    <div v-if="isLoading" class="no-print py-8 text-center text-gray-500">Loading plot list…</div>
 
     <!-- Panels -->
     <div v-for="(panel, i) in panels" :key="i" class="mb-10 panel">

--- a/dashboard/app/components/pages/Event.vue
+++ b/dashboard/app/components/pages/Event.vue
@@ -47,7 +47,7 @@ function parseCSVRow(row: string): string[] {
   return result
 }
 
-/** Strip a single layer of surrounding double-quotes if present (artifact of triple-quoting in CSV). */
+// Strip a single layer of surrounding double-quotes if present (artifact of triple-quoting in CSV).
 function stripQuotes(s: string): string {
   return s.startsWith('"') && s.endsWith('"') ? s.slice(1, -1) : s
 }
@@ -313,8 +313,6 @@ function downloadPDF() {
         <h1 class="font-bold text-2xl mr-3">Event Report</h1>
         <div class="flex flex-col items-center gap-1">
           <u-button
-            variant="ghost"
-            size="lg"
             class="text-4xl"
             @click="loadPreset(PRESET_TSUNAMI, presetTimespans.tsunami)"
             >🌊</u-button
@@ -386,42 +384,42 @@ function downloadPDF() {
     <div v-if="isLoading" class="no-print text-gray-500 py-8 text-center">Loading plot list…</div>
 
     <!-- Panels -->
-    <div v-for="(panel, i) in panels" :key="i" class="panel mb-10">
+    <div v-for="(panel, i) in panels" :key="i" class="mb-10 panel">
       <!-- Controls row (hidden when printing) -->
-      <div class="no-print flex flex-wrap items-center gap-3 mb-4">
+      <div class="flex flex-wrap gap-3 items-center mb-4 no-print">
         <u-select-menu
           v-model="panel.instrument"
-          :items="instruments.map((inst) => ({ label: inst.label, value: inst.key }))"
-          value-key="value"
           class="min-w-72"
+          :items="instruments.map((inst) => ({ label: inst.label, value: inst.key }))"
           placeholder="Select instrument…"
+          value-key="value"
           @update:model-value="panel.parameter = ''"
         />
         <u-select-menu
           v-model="panel.timespan"
-          :items="timeSpans.map((t) => ({ label: t.label, value: t.key }))"
-          value-key="value"
           class="min-w-36"
+          :items="timeSpans.map((t) => ({ label: t.label, value: t.key }))"
           placeholder="Time span…"
+          value-key="value"
         />
         <u-select-menu
           v-model="panel.parameter"
+          class="min-w-48"
           :items="
             getParametersForInstrument(panel.instrument).map((p) => ({
               label: p.label,
               value: p.key,
             }))
           "
-          value-key="value"
-          class="min-w-48"
           placeholder="Parameter…"
+          value-key="value"
         />
         <u-select-menu
           v-model="panel.overlay"
-          :items="overlays.map((o) => ({ label: o.label, value: o.key }))"
-          value-key="value"
           class="min-w-36"
+          :items="overlays.map((o) => ({ label: o.label, value: o.key }))"
           placeholder="Overlay…"
+          value-key="value"
         />
         <u-button
           v-if="panels.length > 1"
@@ -433,7 +431,7 @@ function downloadPDF() {
       </div>
 
       <!-- Print-only label -->
-      <div v-if="panel.instrument && panel.timespan" class="print-only mb-2">
+      <div v-if="panel.instrument && panel.timespan" class="mb-2 print-only">
         <p class="font-semibold text-lg">
           {{ instrumentLabel(panel.instrument) }} — {{ timespanLabel(panel.timespan) }}
         </p>
@@ -446,19 +444,22 @@ function downloadPDF() {
           <img
             v-for="url in getMatchingPlots(panel)"
             :key="url"
-            :src="url"
             alt="Plot"
             class="h-auto max-w-full mb-4 rounded"
             loading="lazy"
+            :src="url"
           />
         </template>
-        <div v-else class="no-print bg-gray-100 p-6 rounded text-gray-500 text-center">
+        <div v-else class="bg-gray-100 no-print p-6 rounded text-center text-gray-500">
           No images found for this selection.
         </div>
       </template>
       <div
         v-else
-        class="no-print bg-gray-50 border border-dashed border-gray-300 p-6 rounded text-center text-gray-400"
+        :class="[
+          'bg-gray-50 border border-dashed border-gray-300 no-print p-6 rounded text-center',
+          'text-gray-400',
+        ]"
       >
         Select instrument and parameters to load images.
       </div>
@@ -466,7 +467,7 @@ function downloadPDF() {
       <!-- Description -->
       <div class="mt-2">
         <button
-          class="no-print flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+          class="flex gap-1 hover:text-gray-700 items-center no-print text-gray-500 text-sm"
           @click="panel.descriptionOpen = !panel.descriptionOpen"
         >
           <u-icon
@@ -477,18 +478,18 @@ function downloadPDF() {
         <textarea
           v-if="panel.descriptionOpen"
           v-model="panel.description"
-          class="no-print mt-2 w-full rounded border border-gray-300 p-2 text-sm"
-          rows="3"
+          class="border border-gray-300 mt-2 no-print p-2 rounded text-sm w-full"
           placeholder="Add notes or description for this panel…"
+          rows="3"
         />
-        <p v-if="panel.description" class="print-only text-sm text-gray-700 mt-1">
+        <p v-if="panel.description" class="mt-1 print-only text-gray-700 text-sm">
           {{ panel.description }}
         </p>
       </div>
     </div>
 
     <!-- Add panel button (hidden when printing) -->
-    <div class="no-print mt-2">
+    <div class="mt-2 no-print">
       <u-button icon="i-lucide-plus" variant="outline" @click="addPanel">
         Add Image Selection
       </u-button>

--- a/dashboard/app/discrete.ts
+++ b/dashboard/app/discrete.ts
@@ -13,11 +13,26 @@ export const enum KnownSampleFields {
 }
 
 export type Sample = Readonly<{
+  type: SampleType
   station: string
-  asset: string
+  asset?: string
   timestamp: ZonedDateTime
   data: SampleData
 }>
+
+const index = [
+  {
+    type: 'summary',
+    file: 'summary-samples.csv',
+  },
+  {
+    type: 'ctd-cast',
+    file: 'ctd-cast-samples.csv',
+  },
+] as const
+
+export const sampleTypes = index.map((entry) => entry.type)
+export type SampleType = (typeof sampleTypes)[number]
 
 export type SampleData = Record<string, SampleValue>
 export type SampleValue = string | number | null
@@ -28,9 +43,9 @@ export type SampleSchemaFieldDefinition = {
   type: SampleValueType
 }
 
-type CsvFile = {
-  name: string
-  content: string
+type RawSampleGroup = {
+  type: SampleType
+  samples: RawSample[]
 }
 
 const timestampRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
@@ -39,8 +54,6 @@ const timestampRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
 const fill = -9999999
 
 export const useDiscrete = defineStore('discrete', () => {
-  // List of CSV file names.
-  let index = $shallowRef<string[]>([])
   // Parsed discrete samples.
   let samples = $shallowRef<Sample[]>([])
   // Inferred schema for discrete samples.
@@ -50,22 +63,19 @@ export const useDiscrete = defineStore('discrete', () => {
     console.log('Loading discrete data.')
     const start = performance.now()
 
-    const loadedIndex = await getIndex()
-    const loadedRawSamples = await getRawSamples(loadedIndex)
-    const [loadedSamples, loadedSchema] = extractSamples(loadedRawSamples)
+    const groups = await Promise.all(index.map(({ type, file }) => getRawSamples(type, file)))
+
+    const [extractedSamples, extractedSchema] = extractSamples(groups)
 
     const end = performance.now()
     const duration = ((end - start) / 1000).toFixed(2)
 
-    index = loadedIndex
-    samples = loadedSamples
-    schema = loadedSchema
+    samples = extractedSamples
+    schema = extractedSchema
 
     console.log(
       `Loaded ${samples.length} discrete samples from ${index.length} files in ${duration}s.`,
     )
-
-    return [...index]
   }
 
   const assetsToStation = $computed<Record<string, string>>(() =>
@@ -77,6 +87,10 @@ export const useDiscrete = defineStore('discrete', () => {
     for (const sample of samples) {
       const station = sample.station
       const asset = sample.asset
+      if (asset == null) {
+        continue
+      }
+
       const assets = (mapping[station] ??= [])
       if (!assets.includes(asset)) {
         assets.push(asset)
@@ -88,7 +102,6 @@ export const useDiscrete = defineStore('discrete', () => {
 
   return {
     load,
-    index: computed(() => index),
     samples: computed(() => samples),
     schema: computed(() => schema),
     fields: computed(() => Object.keys(schema)),
@@ -104,78 +117,68 @@ export const useDiscrete = defineStore('discrete', () => {
   }
 })
 
-async function getIndex(): Promise<string[]> {
-  const response = await fetch('/discrete/index.json')
-  const data: string[] = await response.json()
-  return data
-}
-
-async function getCsvs(index: string[]): Promise<CsvFile[]> {
-  return await Promise.all(
-    index.map(async (name) => {
-      const url = `/discrete/${name}`
-      const response = await fetch(url)
-      const content = await response.text()
-      return { name, content }
-    }),
-  )
-}
-
-async function getRawSamples(index: string[]): Promise<RawSample[]> {
-  const csvs = await getCsvs(index)
-  return csvs.flatMap((csv) => parseRawSamples(csv))
-}
-
-function parseRawSamples(csv: CsvFile): RawSample[] {
-  const parsed = parse(csv.content, {
+async function getRawSamples(type: SampleType, file: string): Promise<RawSampleGroup> {
+  const url = `/discrete/${file}`
+  const response = await fetch(url)
+  const content = await response.text()
+  const parsed = parse(content, {
     header: true,
     skipEmptyLines: true,
   })
 
-  return [...parsed.data] as RawSample[]
+  const samples = [...parsed.data] as RawSample[]
+  return { type, samples }
 }
 
-function extractSamples(raw: RawSample[]): [Sample[], SampleSchema] {
-  const schema = inferSchema(raw)
-  let samples = raw.flatMap((raw) => {
-    // If there are multiple values in a raw sample's station or asset field, split them into
-    // multiple parsed samples for each defined station/asset.
-    const stations =
-      raw[KnownSampleFields.Station]?.split(',')?.map((current) => current.trim()) ?? []
+function extractSamples(groups: RawSampleGroup[]): [Sample[], SampleSchema] {
+  // Infer schema from all raw samples across all groups.
+  const schema = inferSchema(groups.flatMap((file) => file.samples))
 
-    return stations.flatMap((station) => {
-      const assets =
-        raw[KnownSampleFields.Asset]?.split(',')?.map((current) => current.trim()) ?? []
-      return assets.flatMap((asset) => {
-        let timestamp: ZonedDateTime
-        try {
-          timestamp = parseAbsolute(raw[KnownSampleFields.Timestamp] ?? 'unknown', 'UTC')
-        } catch {
-          return []
-        }
+  let samples = groups.flatMap((group) =>
+    group.samples.flatMap((raw) => {
+      // If there are multiple values in a raw sample's station or asset field, split them into
+      // multiple parsed samples for each defined station/asset.
+      const stations =
+        raw[KnownSampleFields.Station]?.split(',')?.map((current) => current.trim()) ?? []
 
-        station = station.split('-').map((current) => current.trim())[0] ?? ''
-        if (station === '') {
-          return []
-        }
-
-        const data: SampleData = {
-          [KnownSampleFields.Station]: station,
-          [KnownSampleFields.Asset]: asset,
-        }
-        for (const [name, value] of Object.entries(raw)) {
-          const field = schema[name]
-          if (field == null || name in data) {
-            continue
+      return stations.flatMap((station) => {
+        const assets =
+          raw[KnownSampleFields.Asset]?.split(',')?.map((current) => current.trim()) ?? []
+        return assets.flatMap((asset) => {
+          if (asset === '') {
+            return []
           }
 
-          data[name] = convertValue(value as string, field)
-        }
+          let timestamp: ZonedDateTime
+          try {
+            timestamp = parseAbsolute(raw[KnownSampleFields.Timestamp] ?? 'unknown', 'UTC')
+          } catch {
+            return []
+          }
 
-        return { station, asset, timestamp, data }
+          station = station.split('-').map((current) => current.trim())[0] ?? ''
+          if (station === '') {
+            return []
+          }
+
+          const data: SampleData = {
+            [KnownSampleFields.Station]: station,
+            [KnownSampleFields.Asset]: asset,
+          }
+          for (const [name, value] of Object.entries(raw)) {
+            const field = schema[name]
+            if (field == null || name in data) {
+              continue
+            }
+
+            data[name] = parseValue(value as string, field)
+          }
+
+          return { type: group.type, station, asset, timestamp, data }
+        })
       })
-    })
-  })
+    }),
+  )
 
   samples = orderBy(samples, [(sample) => sample.asset, (sample) => sample.timestamp.toDate()])
   // Freeze samples to prevent accidental mutations and improve performance in some cases.
@@ -248,7 +251,7 @@ function inferValueType(name: string, raw: string): SampleValueType | null {
   return 'text'
 }
 
-function convertValue(raw: string, field: SampleSchemaFieldDefinition): SampleValue {
+function parseValue(raw: string, field: SampleSchemaFieldDefinition): SampleValue {
   raw = raw.trim()
   if (raw === '') {
     return null

--- a/dashboard/app/discrete.ts
+++ b/dashboard/app/discrete.ts
@@ -3,6 +3,8 @@ import { orderBy, uniq } from 'lodash-es'
 import { parse } from 'papaparse'
 import { defineStore } from 'pinia'
 
+import { sleep } from '~/utilities'
+
 type RawSample = Record<string, string>
 
 export const enum KnownSampleFields {
@@ -58,25 +60,32 @@ export const useDiscrete = defineStore('discrete', () => {
   let samples = $shallowRef<Sample[]>([])
   // Inferred schema for discrete samples.
   let schema = $shallowRef<SampleSchema>({})
+  let loading = $ref(true)
 
   async function load() {
     console.log('Loading discrete data.')
-    const start = performance.now()
+    try {
+      const start = performance.now()
 
-    const groups = await Promise.all(index.map(({ type, file }) => getRawSamples(type, file)))
+      const groups = await Promise.all(index.map(({ type, file }) => getRawSamples(type, file)))
 
-    const [extractedSamples, extractedSchema] = extractSamples(groups)
+      const [extractedSamples, extractedSchema] = await extractSamples(groups)
 
-    const end = performance.now()
-    const duration = ((end - start) / 1000).toFixed(2)
+      const end = performance.now()
+      const duration = ((end - start) / 1000).toFixed(2)
 
-    samples = extractedSamples
-    schema = extractedSchema
+      samples = extractedSamples
+      schema = extractedSchema
 
-    console.log(
-      `Loaded ${samples.length} discrete samples from ${index.length} files in ${duration}s.`,
-    )
+      console.log(
+        `Loaded ${samples.length} discrete samples from ${index.length} files in ${duration}s.`,
+      )
+    } finally {
+      loading = false
+    }
   }
+
+  load()
 
   const assetsToStation = $computed<Record<string, string>>(() =>
     Object.fromEntries(samples.map((sample) => [sample.asset, sample.station])),
@@ -102,6 +111,7 @@ export const useDiscrete = defineStore('discrete', () => {
 
   return {
     load,
+    loading: computed(() => loading),
     samples: computed(() => samples),
     schema: computed(() => schema),
     fields: computed(() => Object.keys(schema)),
@@ -141,44 +151,60 @@ async function getRawSamples(type: SampleType, file: string): Promise<RawSampleG
   const url = `/discrete/${file}`
   const response = await fetch(url)
   const content = await response.text()
-  const parsed = parse(content, {
-    header: true,
-    skipEmptyLines: true,
+
+  const samples = await new Promise<RawSample[]>((resolve) => {
+    parse<RawSample>(content, {
+      header: true,
+      skipEmptyLines: true,
+      worker: true,
+      complete(results) {
+        resolve(results.data)
+      },
+    })
   })
 
-  const samples = [...parsed.data] as RawSample[]
   return { type, samples }
 }
 
-function extractSamples(groups: RawSampleGroup[]): [Sample[], SampleSchema] {
-  // Infer schema from all raw samples across all groups.
-  const schema = inferSchema(groups.flatMap((file) => file.samples))
+/** Number of raw samples to process before yielding to the event loop. */
+const batchSize = 2500
 
-  let samples = groups.flatMap((group) =>
-    group.samples.flatMap((raw) => {
+async function extractSamples(groups: RawSampleGroup[]): Promise<[Sample[], SampleSchema]> {
+  const allRaw = groups.flatMap((file) => file.samples)
+
+  // Infer schema from all raw samples across all groups.
+  const schema = await inferSchema(allRaw)
+
+  await sleep(0)
+
+  const samples: Sample[] = []
+  let processed = 0
+
+  for (const group of groups) {
+    for (const raw of group.samples) {
       // If there are multiple values in a raw sample's station or asset field, split them into
       // multiple parsed samples for each defined station/asset.
       const stations =
         raw[KnownSampleFields.Station]?.split(',')?.map((current) => current.trim()) ?? []
 
-      return stations.flatMap((station) => {
+      for (let station of stations) {
         const assets =
           raw[KnownSampleFields.Asset]?.split(',')?.map((current) => current.trim()) ?? []
-        return assets.flatMap((asset) => {
+        for (const asset of assets) {
           if (asset === '') {
-            return []
+            continue
           }
 
           let timestamp: ZonedDateTime
           try {
             timestamp = parseAbsolute(raw[KnownSampleFields.Timestamp] ?? 'unknown', 'UTC')
           } catch {
-            return []
+            continue
           }
 
           station = station.trim()
           if (station === '') {
-            return []
+            continue
           }
 
           const data: SampleData = {
@@ -194,22 +220,33 @@ function extractSamples(groups: RawSampleGroup[]): [Sample[], SampleSchema] {
             data[name] = parseValue(value as string, field)
           }
 
-          return { type: group.type, station, asset, timestamp, data }
-        })
-      })
-    }),
-  )
+          samples.push({ type: group.type, station, asset, timestamp, data })
+        }
+      }
 
-  samples = orderBy(samples, [(sample) => sample.asset, (sample) => sample.timestamp.toDate()])
+      processed++
+      if (processed % batchSize === 0) {
+        await sleep(0)
+      }
+    }
+  }
+
+  await sleep(0)
+
+  const sorted = orderBy(samples, [(sample) => sample.asset, (sample) => sample.timestamp.toDate()])
+
+  await sleep(0)
+
   // Freeze samples to prevent accidental mutations and improve performance in some cases.
-  samples = samples.map((sample) => Object.freeze(sample))
-  return [samples, schema]
+  const frozen = sorted.map((sample) => Object.freeze(sample))
+  return [frozen, schema]
 }
 
-function inferSchema(raw: RawSample[]): SampleSchema {
+async function inferSchema(raw: RawSample[]): Promise<SampleSchema> {
   let schema: SampleSchema = {}
 
-  for (const sample of raw) {
+  for (let i = 0; i < raw.length; i++) {
+    const sample = raw[i]!
     for (const [name, value] of Object.entries(sample)) {
       const type = inferValueType(name, value)
       if (type == null) {
@@ -233,6 +270,10 @@ function inferSchema(raw: RawSample[]): SampleSchema {
           schema[name] = { type }
         }
       }
+    }
+
+    if (i % batchSize === 0 && i > 0) {
+      await sleep(0)
     }
   }
 

--- a/dashboard/app/discrete.ts
+++ b/dashboard/app/discrete.ts
@@ -9,7 +9,7 @@ export const enum KnownSampleFields {
   Station = 'Station',
   Asset = 'Target Asset',
   Timestamp = 'Start Time [UTC]',
-  Depth = 'CTD Depth [m]',
+  Depth = 'CTD Bottle Depth [m]',
 }
 
 export type Sample = Readonly<{
@@ -108,7 +108,21 @@ export const useDiscrete = defineStore('discrete', () => {
     plottableFields: computed(() =>
       Object.entries(schema)
         .filter(([, definition]) => definition.type !== 'text')
-        .map(([name]) => name),
+        .map(([name]) => name)
+        .sort((left, right) => {
+          // Normalize "CTD Cast X" → "CTD X" so CTD and CTD Cast fields sort together,
+          // then use isCTDCast as a tiebreaker so "CTD X" always precedes "CTD Cast X".
+          const normalize = (field: string) =>
+            field.replace(/^CTD Bottle /, 'CTD ').replace(/^CTD Cast /, 'CTD ')
+          const isCTDCast = (field: string) => (field.startsWith('CTD Cast ') ? 1 : 0)
+          const leftNormalized = normalize(left)
+          const rightNormalized = normalize(right)
+          return leftNormalized < rightNormalized
+            ? -1
+            : leftNormalized > rightNormalized
+              ? 1
+              : isCTDCast(left) - isCTDCast(right)
+        }),
     ),
     stations: computed(() => uniq(samples.map((sample) => sample.station)).sort()),
     assets: computed(() => uniq(samples.map((sample) => sample.asset)).sort()),
@@ -156,7 +170,7 @@ function extractSamples(groups: RawSampleGroup[]): [Sample[], SampleSchema] {
             return []
           }
 
-          station = station.split('-').map((current) => current.trim())[0] ?? ''
+          station = station.trim()
           if (station === '') {
             return []
           }

--- a/dashboard/app/discrete.ts
+++ b/dashboard/app/discrete.ts
@@ -9,7 +9,7 @@ export const enum KnownSampleFields {
   Station = 'Station',
   Asset = 'Target Asset',
   Timestamp = 'Start Time [UTC]',
-  Depth = 'CTD Bottle Depth [m]',
+  Depth = 'CTD Depth [m]',
 }
 
 export type Sample = Readonly<{
@@ -105,25 +105,31 @@ export const useDiscrete = defineStore('discrete', () => {
     samples: computed(() => samples),
     schema: computed(() => schema),
     fields: computed(() => Object.keys(schema)),
-    plottableFields: computed(() =>
-      Object.entries(schema)
-        .filter(([, definition]) => definition.type !== 'text')
+    plottableFields: computed(() => {
+      const fields = Object.entries(schema)
+        .filter(([name, definition]) => {
+          if (definition.type === 'text') return false
+          const lower = name.toLowerCase()
+          if (lower.includes('latitude') || lower.includes('longitude')) return false
+          return true
+        })
         .map(([name]) => name)
-        .sort((left, right) => {
-          // Normalize "CTD Cast X" → "CTD X" so CTD and CTD Cast fields sort together,
-          // then use isCTDCast as a tiebreaker so "CTD X" always precedes "CTD Cast X".
-          const normalize = (field: string) =>
-            field.replace(/^CTD Bottle /, 'CTD ').replace(/^CTD Cast /, 'CTD ')
-          const isCTDCast = (field: string) => (field.startsWith('CTD Cast ') ? 1 : 0)
-          const leftNormalized = normalize(left)
-          const rightNormalized = normalize(right)
-          return leftNormalized < rightNormalized
-            ? -1
-            : leftNormalized > rightNormalized
-              ? 1
-              : isCTDCast(left) - isCTDCast(right)
-        }),
-    ),
+
+      // Preserve original column order, but move "CTD Cast" fields to the end, and
+      // "Water Depth [m]" just before them.
+      const rank = (field: string) => {
+        if (field.startsWith('CTD Cast ')) {
+          return 2
+        }
+        if (field === 'Water Depth [m]') {
+          return 1
+        }
+
+        return 0
+      }
+      return fields.sort((left, right) => rank(left) - rank(right))
+    }),
+
     stations: computed(() => uniq(samples.map((sample) => sample.station)).sort()),
     assets: computed(() => uniq(samples.map((sample) => sample.asset)).sort()),
     assetToStation: computed(() => assetsToStation),

--- a/dashboard/app/pages/discrete.vue
+++ b/dashboard/app/pages/discrete.vue
@@ -5,5 +5,7 @@ definePageMeta({
 </script>
 
 <template>
-  <discrete-page />
+  <client-only>
+    <discrete-page />
+  </client-only>
 </template>

--- a/dashboard/app/pages/discrete.vue
+++ b/dashboard/app/pages/discrete.vue
@@ -5,7 +5,5 @@ definePageMeta({
 </script>
 
 <template>
-  <client-only>
-    <discrete-page />
-  </client-only>
+  <discrete-page />
 </template>

--- a/dashboard/app/persisted.ts
+++ b/dashboard/app/persisted.ts
@@ -21,6 +21,8 @@ export type LocalStoragePersistenceMethod<TData extends Mapping> = {
 
 export type URLPersistenceMethod<TData extends Mapping> = {
   type: 'url'
+  /** Field names to strip from nested objects and arrays before writing to the URL. */
+  omit?: string[]
 } & BasePersistenceMethod<TData>
 
 export type PersistenceMethod<TData extends Mapping> =
@@ -178,7 +180,8 @@ function writeToUrl<TData extends BaseData<TSchema>, TSchema extends BaseSchema>
       continue
     }
 
-    search.set(key, JSON.stringify(value))
+    const stripped = method.omit ? stripFields(value, method.omit) : value
+    search.set(key, JSON.stringify(stripped))
   }
 
   const params = url.searchParams.toString()
@@ -263,6 +266,25 @@ function isPrimitiveField(schema: BaseSchema, field: string): boolean {
     isFieldOfType(schema, field, ZodString) ||
     isFieldOfType(schema, field, ZodEnum)
   )
+}
+
+/** Strip the given field names from all objects nested within a value. */
+function stripFields(value: unknown, fields: string[]): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripFields(item, fields))
+  }
+
+  if (value != null && typeof value === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [key, inner] of Object.entries(value)) {
+      if (!fields.includes(key)) {
+        result[key] = stripFields(inner, fields)
+      }
+    }
+    return result
+  }
+
+  return value
 }
 
 function isPrimitiveArrayField(schema: BaseSchema, field: string): boolean {

--- a/dashboard/app/store.ts
+++ b/dashboard/app/store.ts
@@ -321,7 +321,6 @@ export const useStore = defineStore('store', () => {
       {
         title: 'QAQC HITL Notes Interface',
         route:
-          // eslint-disable-next-line max-len
           'https://www.appsheet.com/Account/Login?appName=RCA%20HITL%20Notes%20Interface&FullScope=False&provider=google&returnUrl=https%3A%2F%2Fwww.appsheet.com%2Fstart%2F8a3bfde2-1806-4155-847c-b10e555ddea1%3Fplatform%3Ddesktop#appName=SensorNotesTracker-59462577&vss=H4sIAAAAAAAAA6WOvQrCMBRGX0W-OU-QVRxE6lJxMR1icwvBNilNqpaQd_fWHzqr4_0u53ASrpZuZdT1BfKUlmtHEySSwmHqSUEqrL2Lg28VhMJed6-xmFYlueCHoJCRK_ExRAqQ6VuB_LdAwBpy0TaWhtk2s2x5k_yeOR4WClmgG6M-t_TMZipn3hpfj4HMkXN-yghbt7n32pnCG5Y2ug2UH3J6VTNvAQAA&view=My%20Sensors',
         external: true,
       },

--- a/dashboard/app/undo.ts
+++ b/dashboard/app/undo.ts
@@ -1,21 +1,23 @@
 import { useEventListener } from '@vueuse/core'
 import { cloneDeep, isEqual } from 'lodash-es'
 
+const maxHistoryLength = 250
+
 export type UndoRedoOptions<T> = {
-  initial: T
+  current: () => T
   onUndo?: (state: T) => void
   onRedo?: (state: T) => void
   handleKeypresses?: MaybeRefOrGetter<boolean>
 }
 
 export function useUndo<T>({
-  initial,
+  current,
   onUndo = () => {},
   onRedo = () => {},
   ...options
 }: UndoRedoOptions<T>) {
   const handleKeypress = $computed(() => toValue(options.handleKeypresses) ?? true)
-  const history = shallowReactive<T[]>([cloneDeep(initial)])
+  const history = shallowReactive<T[]>([cloneDeep(current())])
 
   const canUndo = $computed(() => history.length > 0 && index > 0)
   const canRedo = $computed(() => index < history.length - 1)
@@ -40,11 +42,16 @@ export function useUndo<T>({
     }
   }
 
-  function save(state: T) {
+  function save(state?: T) {
+    const value = state !== undefined ? state : current()
+
     history.splice(index + 1)
     // Only save the new state if it's different from the previous saved state.
-    if (history.length === 0 || !isEqual(state, history[history.length - 1])) {
-      history.push(cloneDeep(state))
+    if (history.length === 0 || !isEqual(value, history[history.length - 1])) {
+      history.push(cloneDeep(value))
+      if (history.length > maxHistoryLength) {
+        history.splice(0, history.length - maxHistoryLength)
+      }
     }
 
     index = history.length - 1

--- a/dashboard/app/utilities.ts
+++ b/dashboard/app/utilities.ts
@@ -8,6 +8,11 @@ export function isPNG(url: string) {
   return url.toLowerCase().endsWith('.png')
 }
 
+/** Sleep for the given number of milliseconds, yielding to the event loop. */
+export function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
 export function debouncedComputed<T>(getter: () => T, delay: number) {
   let value = $ref(getter()) as T
 

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -15,7 +15,7 @@ export default withNuxt([
     },
     rules: {
       'no-undef': 'off', // Handled by TypeScript.
-      'max-len': ['warn', 100, 2],
+      'max-len': ['warn', 100, 2, { ignoreStrings: true }],
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-dynamic-delete': 'off',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -17,6 +17,7 @@
         "@pinia/nuxt": "^0.11.3",
         "@vue-macros/nuxt": "^3.1.1",
         "@vueuse/core": "^12.2.1",
+        "color": "^5.0.3",
         "echarts": "^6.0.0",
         "lodash-es": "^4.17.21",
         "nuxt": "^4.3.1",
@@ -29,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
+        "@types/color": "^4.2.1",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^24.6.0",
         "@types/papaparse": "^5.5.1",
@@ -3665,6 +3667,33 @@
         "yjs": "^13.5.38"
       }
     },
+    "node_modules/@types/color": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-4.2.1.tgz",
+      "integrity": "sha512-ResWeDLy1vozIMbD6JLRKuNBbIcIlBkjTIxVHHd5Cqtm77T+ahH3BWE/PWv1OhFd1HAwcn8no4ig2uTaRXpYQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-convert": "2"
+      }
+    },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.0"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "dev": true,
@@ -5931,6 +5960,19 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
@@ -5944,6 +5986,48 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -14925,18 +15009,6 @@
       "version": "2.4.23",
       "license": "MIT"
     },
-    "node_modules/vue-macros/node_modules/@volar/typescript": {
-      "version": "2.4.23",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz",
-      "integrity": "sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@volar/language-core": "2.4.23",
-        "path-browserify": "^1.0.1",
-        "vscode-uri": "^3.0.8"
-      }
-    },
     "node_modules/vue-macros/node_modules/@vue-macros/volar": {
       "version": "3.1.2",
       "license": "MIT",
@@ -14991,23 +15063,6 @@
     "node_modules/vue-macros/node_modules/alien-signals": {
       "version": "2.0.8",
       "license": "MIT"
-    },
-    "node_modules/vue-macros/node_modules/vue-tsc": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.8.tgz",
-      "integrity": "sha512-H9yg/m6ywykmWS+pIAEs65v2FrVm5uOA0a0dHkX6Sx8dNg1a1m4iudt/6eGa9fAenmNHGlLFN9XpWQb8i5sU1w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@volar/typescript": "2.4.23",
-        "@vue/language-core": "3.0.8"
-      },
-      "bin": {
-        "vue-tsc": "bin/vue-tsc.js"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.0"
-      }
     },
     "node_modules/vue-router": {
       "version": "4.6.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,6 +21,7 @@
     "@pinia/nuxt": "^0.11.3",
     "@vue-macros/nuxt": "^3.1.1",
     "@vueuse/core": "^12.2.1",
+    "color": "^5.0.3",
     "echarts": "^6.0.0",
     "lodash-es": "^4.17.21",
     "nuxt": "^4.3.1",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",
+    "@types/color": "^4.2.1",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^24.6.0",
     "@types/papaparse": "^5.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,6 @@ dependencies = [
     "pip",
     "tqdm",
     "rca-data-tools @ git+https://github.com/OOI-CabledArray/rca-data-tools.git",
+    "requests>=2.32.5",
+    "beautifulsoup4>=4.14.2",
 ]

--- a/scripts/collect_discrete_ctd_cast_samples.py
+++ b/scripts/collect_discrete_ctd_cast_samples.py
@@ -96,6 +96,12 @@ MONTHS = {
 }
 
 
+def normalize_cast(value: str) -> str:
+    """Strip 'CTD-' prefix and leading zeros, returning the integer string or empty."""
+    value = re.sub(r"^CTD-", "", value.strip(), flags=re.IGNORECASE).lstrip("0") or "0"
+    return value if value.isdigit() else ""
+
+
 def normalize_ctd_file_key(key: str) -> str:
     """
     Strip hyphens from the cruise portion of a CTD file key and normalize the separator to "_".
@@ -247,10 +253,18 @@ def parse(
         log.error("Cannot read %s: %s", path, exc)
         return
 
+    # Extract the cast number from the filename (e.g. "TN326_CTD-018" -> "18").
+    filename_cast = ""
+    file_key_match = _CTD_FILE_KEY_RE.match(path.stem.split("__")[-1])
+    if file_key_match:
+        filename_cast = normalize_cast(file_key_match.group(2))
+
     with file:
         # Parse header: metadata and column definitions (line by line).
         # Use readline() instead of iteration so that tell()/seek() work later.
         meta: dict[str, Any] = {}
+        if filename_cast:
+            meta["Cast"] = filename_cast
         columns: dict[int, str] = {}
         found_end = False
 
@@ -279,7 +293,9 @@ def parse(
                 if value:
                     csv_key = META_KEY_TO_COLUMN_MAP.get(raw_key)
                     if csv_key and csv_key not in meta:
-                        meta[csv_key] = value
+                        meta[csv_key] = (
+                            normalize_cast(value) if csv_key == "Cast" else value
+                        )
                 continue
 
             sys_header_match = SYS_REGEX.match(line)
@@ -287,13 +303,17 @@ def parse(
                 raw_key = sys_header_match.group(1).strip().lower()
                 value = sys_header_match.group(2).strip()
                 if "nmea latitude" in raw_key:
-                    coord = parse_nmea_coordinates(value)
-                    if coord is not None:
-                        meta["CTD Cast Start Latitude [degrees]"] = coord
+                    lat_column = COLUMN_MAP.get("latitude")
+                    if lat_column and lat_column not in meta:
+                        parsed = parse_nmea_coordinates(value)
+                        if parsed is not None:
+                            meta[lat_column] = str(parsed)
                 elif "nmea longitude" in raw_key:
-                    coord = parse_nmea_coordinates(value)
-                    if coord is not None:
-                        meta["CTD Cast Start Longitude [degrees]"] = coord
+                    lon_column = COLUMN_MAP.get("longitude")
+                    if lon_column and lon_column not in meta:
+                        parsed = parse_nmea_coordinates(value)
+                        if parsed is not None:
+                            meta[lon_column] = str(parsed)
                 elif "nmea utc" in raw_key:
                     if "Start Time [UTC]" not in meta:
                         iso_time = parse_nmea_utc(value)

--- a/scripts/collect_discrete_ctd_cast_samples.py
+++ b/scripts/collect_discrete_ctd_cast_samples.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""
+Parse all Sea-Bird *.btl bottle files under a given root directory and emit a single CSV/JSON file
+where every line/array element represents one bottle-closure sample.
+
+Usage:
+    ./collect_discrete_ctd_cast_samples.py ROOT [--out FILE] [--format {csv,json}] [--indent N] [--verbose]
+
+The output format is inferred from the extension of `--out` when it is ".csv" or ".json".
+
+If the extension is unrecognised, `--format` is used instead (default: csv).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from csv import DictWriter
+from datetime import datetime, timezone
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)-8s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+# Sea-Bird BTL column names mapping matching the discrete sample column names as closely as
+# possible.
+COLUMN_MAP: dict[str, str] = {
+    "Bottle": "_btl_bottle_number",  # Internal, written as "Bottle Position".
+    "Date": "_btl_date",  # Internal, combined with time to create "Bottle Closure Time [UTC]".
+    "PrDM": "CTD Pressure [db]",
+    "DepSM": "CTD Depth [m]",
+    "Latitude": "CTD Latitude [deg]",
+    "Longitude": "CTD Longitude [deg]",
+    "T090C": "CTD Temperature 1 [deg C]",
+    "T190C": "CTD Temperature 2 [deg C]",
+    "C0S/m": "CTD Conductivity 1 [S/m]",
+    "C1S/m": "CTD Conductivity 2 [S/m]",
+    "Sal00": "CTD Salinity 1 [psu]",
+    "Sal11": "CTD Salinity 2 [psu]",
+    "Sbeox0V": "CTD Oxygen Voltage [V]",
+    "Sbeox0ML/L": "CTD Oxygen [mL/L]",
+    "OxsolML/L": "CTD Oxygen Saturation [mL/L]",
+    "FlECO-AFL": "CTD Fluorescence [mg/m^3]",
+    "FlSP": "CTD Fluorescence [mg/m^3]",
+    "CStarAt0": "CTD Beam Attenuation [1/m]",
+    "CStarTr0": "CTD Beam Transmission [%]",
+    "Ph": "CTD pH",
+}
+
+# Rules for mapping a raw `.btl` Location/Station/Station Name/Station Number string to the
+# canonical station name used in summary-samples.csv.
+#
+# Each entry is a (keywords, station_name) pair.  All keywords in the tuple must appear
+# (case-insensitively) somewhere in the location string for the rule to match.  The first
+# matching rule wins.  More-specific rules (more keywords, or narrower terms) must therefore
+# appear before less-specific ones.
+#
+# Station names deliberately omit the "- <N> m <direction>" offset suffix so that multiple nearby
+# cast positions all resolve to the same base name.  If the matched station name has no recognised
+# platform-type suffix (" Shallow Profiler", " Deep Profiler", " BEP", " Junction Box") one is
+# appended automatically by `_ensure_station_suffix`.
+LOCATION_STATION_RULES: list[tuple[list[str], str]] = [
+    #
+    # Exact CTD-number codes. These must precede generic keyword rules.
+    #
+    # TN326 2015: slope base junction box
+    (["ctd12"], "Slope Base Junction Box LJ01A"),
+    (["ctd13"], "Slope Base Junction Box LJ01A"),
+    (["ctd17"], "Slope Base Junction Box LJ01A"),
+    (["ctd19"], "Slope Base Junction Box LJ01A"),
+    # TN326 2015: slope base shallow profiler
+    (["ctd02"], "Slope Base Shallow Profiler"),
+    (["ctd14"], "Slope Base Shallow Profiler"),
+    # TN326 2015: axial base shallow profiler
+    (["ctd03"], "Axial Base Shallow Profiler"),
+    (["ctd04"], "Axial Base Shallow Profiler"),
+    (["ctd05"], "Axial Base Shallow Profiler"),
+    # SKQ201610S 2016: slope base junction box
+    (["ca_ctd_2016-02"], "Slope Base Junction Box LJ01A"),
+    # SKQ201610S 2016: slope base shallow profiler
+    (["ca_ctd_2016-03"], "Slope Base Shallow Profiler"),
+    (["ca_ctd_2016-06"], "Slope Base Shallow Profiler"),
+    # AT50-29 2024: axial base shallow profiler
+    (["ctd 12"], "Axial Base Shallow Profiler"),
+    (["ctd 13"], "Axial Base Shallow Profiler"),
+    # AT50-29 2024: oregon offshore shallow profiler
+    (["ctd 009"], "Oregon Offshore Shallow Profiler"),
+    (["ctd 14"], "Oregon Offshore Shallow Profiler"),
+    #
+    # Generic keyword rules.
+    #
+    # Slope Base Junction Box
+    (["lv01a"], "Slope Base Junction Box LV01A"),
+    (["lj01a"], "Slope Base Junction Box LJ01A"),
+    (["bubble", "plume"], "Slope Base Junction Box LJ01A"),
+    # Slope Base Deep Profiler
+    (["slope", "base", "dp"], "Slope Base Deep Profiler"),
+    (["slope", "base", "deep"], "Slope Base Deep Profiler"),
+    # Slope Base Shallow Profiler
+    (["slope", "base"], "Slope Base Shallow Profiler"),
+    # Axial Base Deep Profiler
+    (["axial", "dp"], "Axial Base Deep Profiler"),
+    (["axial", "deep"], "Axial Base Deep Profiler"),
+    # Axial Base Shallow Profiler
+    (["axial"], "Axial Base Shallow Profiler"),
+    # Oregon Offshore Deep Profiler
+    (["offshore", "dp"], "Oregon Offshore Deep Profiler"),
+    (["offshore", "deep"], "Oregon Offshore Deep Profiler"),
+    (["offshore", "600"], "Oregon Offshore Deep Profiler"),
+    (["endurance", "dp"], "Oregon Offshore Deep Profiler"),
+    # Oregon Shelf BEP
+    (["shelf"], "Oregon Shelf BEP"),
+    # Oregon Offshore Shallow Profiler
+    (["offshore"], "Oregon Offshore Shallow Profiler"),
+    (["endurance"], "Oregon Offshore Shallow Profiler"),
+]
+
+
+def lookup_station(location: str) -> str | None:
+    """
+    Return the canonical summary-samples.csv station name for a raw btl Location/Station value,
+    or None if no rule matches.
+
+    Each rule in LOCATION_STATION_RULES is checked in order; the first whose keywords are all
+    present (case-insensitively) in `location` wins.
+    """
+    lower = location.lower()
+    for keywords, station_name in LOCATION_STATION_RULES:
+        if all(kw in lower for kw in keywords):
+            return station_name
+    return None
+
+
+# Mapping from raw header keys to CSV column names.
+META_KEY_TO_COLUMN_MAP: dict[str, str] = {
+    "cruise": "Cruise",
+    "cast": "Cast",
+    "station": "Station",
+    "station_name": "Station",
+    "station_number": "Station",
+    "location": "Station",
+    "water_depth": "CTD Cast Water Depth [m]",
+    "depth": "CTD Depth [m]",
+    "date": "Start Time [UTC]",
+}
+
+
+def sanitise_key(column_name: str) -> str:
+    """
+    Convert an unmapped Sea-Bird column name to a safe JSON key by replacing every run of
+    non-alphanumeric characters with a single underscore.
+    """
+    return re.sub(r"[^A-Za-z0-9]+", "_", column_name).strip("_")
+
+
+def column_to_key(column_name: str) -> str:
+    """Return the JSON key for a Sea-Bird column name."""
+    if column_name in COLUMN_MAP:
+        return COLUMN_MAP[column_name]
+
+    return sanitise_key(column_name)
+
+
+def is_stdev_key(key: str) -> bool:
+    """Return `True` if `key` is a standard-deviation companion column."""
+    return key.endswith(" stdev") or key.endswith("_sdev")
+
+
+def stdev_key(measurement_key: str) -> str:
+    """
+    Return the standard-deviation companion key for a measurement key.
+
+    For keys that match CSV column names (contain spaces / brackets) the stdev is appended as a
+    suffix in a consistent way so downstream code can find it. For plain snake_case keys the _sdev
+    suffix is used.
+    """
+    if " " in measurement_key or "[" in measurement_key:
+        return measurement_key + " stdev"
+    return measurement_key + "_sdev"
+
+
+# Regex for a Sea-Bird user-comment metadata line.
+META_REGEX = re.compile(r"^\*\*\s+([A-Za-z ]+?):\s*(.*?)\s*$")
+
+# Regex for a system header line.
+SYS_REGEX = re.compile(r"^\*\s+([A-Za-z /()]+?)\s*=\s*(.*?)\s*$")
+
+# Month abbreviations used when parsing date strings.
+MONTHS = {
+    name: number
+    for number, name in enumerate(
+        (
+            "jan",
+            "feb",
+            "mar",
+            "apr",
+            "may",
+            "jun",
+            "jul",
+            "aug",
+            "sep",
+            "oct",
+            "nov",
+            "dec",
+        ),
+        start=1,
+    )
+}
+
+
+def parse_datetime(text: str, time_text: str) -> str | None:
+    """
+    Combine a date token like "Aug 06 2021" and a time token like "00:08:19" into an ISO-8601 UTC
+    string. Returns `None` on failure.
+    """
+    try:
+        parts = text.split()
+        if len(parts) == 3:
+            month = MONTHS.get(parts[0].lower())
+            if month is None:
+                return None
+            day = int(parts[1])
+            year = int(parts[2])
+        else:
+            return None
+
+        hour, minute, second = (int(part) for part in time_text.split(":"))
+        return datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            tzinfo=timezone.utc,
+        ).isoformat()
+    except Exception:
+        return None
+
+
+def parse_nmea_utc(value: str) -> str | None:
+    """
+    Convert an NMEA UTC header string like "Jul 06 2015 15:59:45" to an ISO-8601 UTC string. Returns
+    `None` on failure.
+    """
+    try:
+        # Format: "Mon DD YYYY HH:MM:SS"
+        nmea_parts = value.split()
+        if len(nmea_parts) != 4:
+            return None
+        date_str = " ".join(nmea_parts[:3])  # "Jul 06 2015"
+        time_str = nmea_parts[3]  # "15:59:45"
+        return parse_datetime(date_str, time_str)
+    except Exception:
+        return None
+
+
+def parse_nmea_coordinates(value: str) -> float | None:
+    """
+    Convert an NMEA degree-minute string like "44 31.57 N" or "125 23.67 W" to a signed decimal
+    degree float.
+    """
+    try:
+        parts = value.split()
+        if len(parts) != 3:
+            return None
+        degrees = float(parts[0])
+        minutes = float(parts[1])
+        hemisphere = parts[2].upper()
+        decimal_degrees = degrees + minutes / 60.0
+        if hemisphere in {"S", "W"}:
+            decimal_degrees = -decimal_degrees
+        return round(decimal_degrees, 6)
+    except Exception:
+        return None
+
+
+def coerce_number(value: str) -> float | str:
+    """Try to parse `value` as float; return the original string on failure."""
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def parse(path: Path) -> list[dict[str, Any]]:
+    try:
+        text = path.read_text(encoding="latin-1")
+    except OSError as exc:
+        log.error("Cannot read %s: %s", path, exc)
+        return []
+
+    lines = text.splitlines()
+
+    #
+    # Extract header metadata values, which are values included in all samples.
+    #
+    meta: dict[str, Any] = {}
+
+    for line in path.open(encoding="latin-1"):
+        # User-defined comment fields:  ** Cruise: TN393
+        user_comment_match = META_REGEX.match(line)
+        if user_comment_match:
+            raw_key = re.sub(r"\s+", "_", user_comment_match.group(1).strip().lower())
+            value = user_comment_match.group(2).strip()
+            if value:
+                csv_key = META_KEY_TO_COLUMN_MAP.get(raw_key)
+                if csv_key:
+                    # "Station" can be supplied by multiple source keys, first wins.
+                    if csv_key not in meta:
+                        if csv_key == "Station":
+                            canonical = lookup_station(value)
+                            if canonical is not None:
+                                meta["Station"] = canonical
+                            else:
+                                log.warning(
+                                    "No station mapping found for location %r in %s, skipping.",
+                                    value,
+                                    path,
+                                )
+                        else:
+                            meta[csv_key] = value
+
+            continue
+
+        # System header fields.
+        sys_header_match = SYS_REGEX.match(line)
+        if sys_header_match:
+            raw_key = sys_header_match.group(1).strip().lower()
+            value = sys_header_match.group(2).strip()
+            if "nmea latitude" in raw_key:
+                coord = parse_nmea_coordinates(value)
+                if coord is not None:
+                    meta["Start Latitude [degrees]"] = coord
+            elif "nmea longitude" in raw_key:
+                coord = parse_nmea_coordinates(value)
+                if coord is not None:
+                    meta["Start Longitude [degrees]"] = coord
+            elif "nmea utc" in raw_key:
+                # Only use as Start Time fallback if not already set by ** Date
+                if "Start Time [UTC]" not in meta:
+                    iso_time = parse_nmea_utc(value)
+                    meta["Start Time [UTC]"] = (
+                        iso_time if iso_time is not None else value
+                    )
+            elif "software version" in raw_key:
+                meta["software_version"] = value
+            continue
+
+        # Stop scanning metadata once we hit the data section
+        if line.strip().startswith("Bottle") and "Date" in line:
+            break
+
+    # Find column header line and parse column names.
+    header_line_index: int | None = None
+    raw_columns: list[str] = []
+
+    for line_index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("Bottle") and "Date" in stripped:
+            # Split on whitespace. The header uses fixed-width layout but whitespace splitting is
+            # reliable for the column names themselves.
+            raw_columns = stripped.split()
+            header_line_index = line_index
+            break
+
+    if "Station" not in meta:
+        return []
+
+    if header_line_index is None:
+        log.warning("No data header found in %s, skipping.", path)
+        return []
+
+    # Map Sea-Bird column names → clean JSON keys
+    json_keys = [column_to_key(column_name) for column_name in raw_columns]
+
+    #
+    # Parse data rows.
+    #
+    # The BTL format interleaves "avg" and "sdev" rows, but we really only care about the averages.
+    #
+    # The bottle number and date appear on the avg row; the time of day
+    # appears in the same column position as "Date" on the sdev row.
+    # We combine them into a single ISO timestamp.
+    #
+    # Skip the "Position  Time  ..." unit row immediately after the header.
+    data_start_index = header_line_index + 2
+    if data_start_index < len(lines) and "Position" in lines[data_start_index - 1]:
+        pass  # already correct — unit row was at header_line_index + 1
+
+    samples: list[dict[str, Any]] = []
+    row_index = data_start_index
+
+    while row_index < len(lines):
+        avg_line = lines[row_index]
+
+        # Skip blank lines
+        if not avg_line.strip():
+            row_index += 1
+            continue
+
+        if not avg_line.strip().endswith("(avg)"):
+            row_index += 1
+            continue
+
+        # Peek at the next non-empty line to get the sdev row.
+        sdev_line = ""
+        sdev_search_index = row_index + 1
+        while sdev_search_index < len(lines):
+            if lines[sdev_search_index].strip():
+                if lines[sdev_search_index].strip().endswith("(sdev)"):
+                    sdev_line = lines[sdev_search_index]
+                break
+            sdev_search_index += 1
+
+        # Parse the "avg" row, stripping the trailing "(avg)" marker before splitting.
+        avg_values_raw = avg_line.strip().rstrip("(avg)").strip()
+        # The first token is the bottle number, the next three tokens form the date ("Aug 06 2021"),
+        # then the remaining tokens are numeric values.
+        avg_tokens = avg_values_raw.split()
+
+        # ---- Parse the sdev row ----------------------------------------
+        sdev_tokens: list[str] = []
+        if sdev_line:
+            sdev_values_raw = sdev_line.strip().rstrip("(sdev)").strip()
+            sdev_tokens = sdev_values_raw.split()
+
+        # Reconstruct per-column token lists.
+        avg_column_tokens: list[str | None] = []
+        sdev_column_tokens: list[str | None] = []
+
+        try:
+            # Append bottle number.
+            avg_column_tokens.append(avg_tokens[0])
+            # No bottle number on sdev row.
+            sdev_column_tokens.append(None)
+
+            # Date is 3 tokens, time is 1.
+            date_text = " ".join(avg_tokens[1:4])
+            avg_column_tokens.append(date_text)
+
+            time_text = sdev_tokens[0] if sdev_tokens else None
+            sdev_column_tokens.append(time_text)
+
+            # Remaining numeric columns, one token each.
+            for avg_token_index in range(4, len(avg_tokens)):
+                avg_column_tokens.append(avg_tokens[avg_token_index])
+            for sdev_token_index in range(1, len(sdev_tokens)):
+                sdev_column_tokens.append(sdev_tokens[sdev_token_index])
+
+        except IndexError:
+            log.warning(
+                "Malformed row in %s at line %d, skipping bottle.", path, row_index + 1
+            )
+            row_index = sdev_search_index + 1
+            continue
+
+        # Build the sample with "Station" and "Target Asset" at the front.
+        station = meta["Station"]
+        sample: dict[str, Any] = {
+            "Station": station,
+            "Target Asset": f"CTD Cast ({station})",
+            **{key: value for key, value in meta.items() if key != "Station"},
+        }
+
+        # Populate measured columns.
+        date_part: str = ""
+        time_part: str = ""
+
+        for column_index, json_key in enumerate(json_keys):
+            avg_text = (
+                avg_column_tokens[column_index]
+                if column_index < len(avg_column_tokens)
+                else None
+            )
+            sdev_text = (
+                sdev_column_tokens[column_index]
+                if column_index < len(sdev_column_tokens)
+                else None
+            )
+
+            if json_key == "_btl_bottle_number":
+                sample["CTD Cast Bottle Position"] = (
+                    int(avg_text) if avg_text is not None else None
+                )
+
+            elif json_key == "_btl_date":
+                # Defer writing the datetime until we also have the time.
+                date_part = avg_text or ""
+                time_part = sdev_text or ""
+
+            else:
+                # Numeric measurement, skip internal sentinel keys.
+                if json_key.startswith("_btl_"):
+                    continue
+                if avg_text is not None:
+                    sample[json_key] = coerce_number(avg_text)
+                if sdev_text is not None:
+                    sample[stdev_key(json_key)] = coerce_number(sdev_text)
+
+        # Combine date and time into ISO-8601 UTC → "CTD Bottle Closure Time [UTC]".
+        if date_part and time_part:
+            iso = parse_datetime(date_part, time_part)
+            if iso:
+                sample["CTD Cast Bottle Closure Time [UTC]"] = iso
+            else:
+                sample["CTD Cast Bottle Closure Time [UTC]"] = (
+                    f"{date_part} {time_part}"
+                )
+        elif date_part:
+            sample["CTD Cast Bottle Closure Time [UTC]"] = date_part
+
+        # Drop stdev keys before storing.
+        sample = {key: value for key, value in sample.items() if not is_stdev_key(key)}
+        samples.append(sample)
+        row_index = sdev_search_index + 1
+
+    return samples
+
+
+def write_samples_as_json(
+    samples: list[dict[str, Any]],
+    output: Path,
+    indent: int,
+) -> None:
+    with output.open("w", encoding="utf-8") as stream:
+        json.dump(
+            samples,
+            stream,
+            indent=indent or None,
+            ensure_ascii=False,
+        )
+        stream.write("\n")
+
+
+def write_samples_as_csv(samples: list[dict[str, Any]], output: Path) -> None:
+
+    columns: dict[str, None] = {}
+    for sample in samples:
+        # Add keys from all fields, values are updated here, but ignored. Preserve insertion order
+        # by using dictionary keys as an ordered set.
+        columns.update(sample)
+
+    with output.open("w", encoding="utf-8", newline="") as stream:
+        writer = DictWriter(
+            stream,
+            fieldnames=list(columns),
+            extrasaction="ignore",
+        )
+        writer.writeheader()
+        writer.writerows(samples)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert all *.btl files under ROOT to a single JSON or CSV file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=dedent("""
+          examples:
+            # Write to the default output path (<root_name>.csv).
+            ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/
+            # Write to a JSON file (format inferred from extension).
+            ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/ --out ctd-cast-source-files.json
+            # Override format explicitly.
+            ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/ --out ctd-cast-source-files.json
+            # Use compact JSON output with no indentation.
+            ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/ --out ctd-cast-source-files.json --indent 0
+        """),
+    )
+    parser.add_argument(
+        "root",
+        type=Path,
+        metavar="ROOT",
+        help="Root directory to search recursively for *.btl files.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["csv", "json"],
+        default=None,
+        dest="format",
+        help="Output format: csv or json. Takes priority over the extension of --out. (default: csv)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help=(
+            "Output file path. Format is inferred from the extension (.csv or .json) "
+            "when recognised, otherwise --format is used. "
+            "Defaults to <root_directory_name>.csv in the current directory."
+        ),
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        metavar="N",
+        help="JSON indentation level, use 0 for compact output. (default: 2)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    root: Path = args.root
+    if not root.exists():
+        log.error("Root directory '%s' does not exist.", root)
+        return 1
+
+    if args.format is not None:
+        # The `--format` was explicitly provided, and takes priority.
+        format = args.format
+        out = args.out if args.out is not None else Path(f"{root.name}.{format}")
+    elif args.out is not None:
+        # No explicit `--format`, infer from the file extension.
+        extension = args.out.suffix.lower()[1:]
+        if extension in {"csv", "json"}:
+            format = extension
+        else:
+            log.warning(
+                "Unrecognised extension '.%s' in --out, defaulting to 'csv'.",
+                extension,
+            )
+            format = "csv"
+        out = args.out
+    else:
+        # Neither `--format` or `--out` provided, use defaults.
+        format = "csv"
+        out = Path(f"{root.name}.csv")
+
+    files = sorted(root.rglob("*.btl"))
+    if not files:
+        log.error("No *.btl files found under '%s', exiting.", root)
+        return 1
+
+    log.info("Found %s *.btl file(s) under '%s'.", len(files), root)
+
+    samples: list[dict[str, Any]] = []
+
+    for file in files:
+        log.debug("Parsing '%s'.", file)
+        file_samples = parse(file)
+        log.info("  '%s' (%s sample(s))", file, len(file_samples))
+        samples.extend(file_samples)
+
+    log.info("Parsed %s sample(s) from %s file(s).", len(samples), len(files))
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    match format:
+        case "csv":
+            write_samples_as_csv(samples, out)
+        case "json":
+            write_samples_as_json(samples, out, args.indent)
+
+    log.info(f"'{out}': ({out.stat().st_size / 1024:.1f} KB)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/collect_discrete_ctd_cast_samples.py
+++ b/scripts/collect_discrete_ctd_cast_samples.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """
-Parse all Sea-Bird *.btl bottle files under a given root directory and emit a single CSV/JSON file
-where every line/array element represents one bottle-closure sample.
+Parse all Sea-Bird *.cnv profile files under a given root directory and emit a single CSV/JSON file
+where every line/array element represents one CTD scan.
+
+The Station for each sample is resolved by matching the CTD file key embedded in each .cnv
+filename (e.g. "TN326_CTD-001") against the "CTD File" column of the summary samples CSV
+supplied via `--summary-samples`.
 
 Usage:
-    ./collect_discrete_ctd_cast_samples.py ROOT [--out FILE] [--format {csv,json}] [--indent N] [--verbose]
+    ./collect_discrete_ctd_cast_samples.py ROOT --summary-samples SUMMARY_CSV [--out FILE] [--format {csv,json}] [--indent N] [--verbose]
 
 The output format is inferred from the extension of `--out` when it is ".csv" or ".json".
 
@@ -14,12 +18,13 @@ If the extension is unrecognised, `--format` is used instead (default: csv).
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import logging
 import re
 import sys
+from collections.abc import Iterator
 from csv import DictWriter
-from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
@@ -30,168 +35,43 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-# Sea-Bird BTL column names mapping matching the discrete sample column names as closely as
-# possible.
+# Sea-Bird CNV short column names → output column names.
+# Keys are compared case-insensitively.
 COLUMN_MAP: dict[str, str] = {
-    "Bottle": "_btl_bottle_number",  # Internal, written as "Bottle Position".
-    "Date": "_btl_date",  # Internal, combined with time to create "Bottle Closure Time [UTC]".
-    "PrDM": "CTD Pressure [db]",
-    "DepSM": "CTD Depth [m]",
-    "Latitude": "CTD Latitude [deg]",
-    "Longitude": "CTD Longitude [deg]",
-    "T090C": "CTD Temperature 1 [deg C]",
-    "T190C": "CTD Temperature 2 [deg C]",
-    "C0S/m": "CTD Conductivity 1 [S/m]",
-    "C1S/m": "CTD Conductivity 2 [S/m]",
-    "Sal00": "CTD Salinity 1 [psu]",
-    "Sal11": "CTD Salinity 2 [psu]",
-    "Sbeox0V": "CTD Oxygen Voltage [V]",
-    "Sbeox0ML/L": "CTD Oxygen [mL/L]",
-    "OxsolML/L": "CTD Oxygen Saturation [mL/L]",
-    "FlECO-AFL": "CTD Fluorescence [mg/m^3]",
-    "FlSP": "CTD Fluorescence [mg/m^3]",
-    "CStarAt0": "CTD Beam Attenuation [1/m]",
-    "CStarTr0": "CTD Beam Transmission [%]",
-    "Ph": "CTD pH",
+    "prdm": "CTD Cast Pressure [db]",
+    "depsm": "CTD Cast Depth [m]",
+    "latitude": "CTD Cast Latitude [deg]",
+    "longitude": "CTD Cast Longitude [deg]",
+    "t090c": "CTD Cast Temperature 1 [deg C]",
+    "t190c": "CTD Cast Temperature 2 [deg C]",
+    "c0s/m": "CTD Cast Conductivity 1 [S/m]",
+    "c1s/m": "CTD Cast Conductivity 2 [S/m]",
+    "sal00": "CTD Cast Salinity 1 [psu]",
+    "sal11": "CTD Cast Salinity 2 [psu]",
+    "sbeox0v": "CTD Cast Oxygen Voltage [V]",
+    "sbeox0ml/l": "CTD Cast Oxygen [mL/L]",
+    "oxsolml/l": "CTD Cast Oxygen Saturation [mL/L]",
+    "fleco-afl": "CTD Cast Fluorescence [mg/m^3]",
+    "flsp": "CTD Cast Fluorescence [mg/m^3]",
+    "cstarat0": "CTD Cast Beam Attenuation [1/m]",
+    "cstartr0": "CTD Cast Beam Transmission [%]",
+    "ph": "CTD Cast pH",
+    "times": "CTD Cast Time [seconds]",
 }
 
-# Rules for mapping a raw `.btl` Location/Station/Station Name/Station Number string to the
-# canonical station name used in summary-samples.csv.
-#
-# Each entry is a (keywords, station_name) pair.  All keywords in the tuple must appear
-# (case-insensitively) somewhere in the location string for the rule to match.  The first
-# matching rule wins.  More-specific rules (more keywords, or narrower terms) must therefore
-# appear before less-specific ones.
-#
-# Station names deliberately omit the "- <N> m <direction>" offset suffix so that multiple nearby
-# cast positions all resolve to the same base name.  If the matched station name has no recognised
-# platform-type suffix (" Shallow Profiler", " Deep Profiler", " BEP", " Junction Box") one is
-# appended automatically by `_ensure_station_suffix`.
-LOCATION_STATION_RULES: list[tuple[list[str], str]] = [
-    #
-    # Exact CTD-number codes. These must precede generic keyword rules.
-    #
-    # TN326 2015: slope base junction box
-    (["ctd12"], "Slope Base Junction Box LJ01A"),
-    (["ctd13"], "Slope Base Junction Box LJ01A"),
-    (["ctd17"], "Slope Base Junction Box LJ01A"),
-    (["ctd19"], "Slope Base Junction Box LJ01A"),
-    # TN326 2015: slope base shallow profiler
-    (["ctd02"], "Slope Base Shallow Profiler"),
-    (["ctd14"], "Slope Base Shallow Profiler"),
-    # TN326 2015: axial base shallow profiler
-    (["ctd03"], "Axial Base Shallow Profiler"),
-    (["ctd04"], "Axial Base Shallow Profiler"),
-    (["ctd05"], "Axial Base Shallow Profiler"),
-    # SKQ201610S 2016: slope base junction box
-    (["ca_ctd_2016-02"], "Slope Base Junction Box LJ01A"),
-    # SKQ201610S 2016: slope base shallow profiler
-    (["ca_ctd_2016-03"], "Slope Base Shallow Profiler"),
-    (["ca_ctd_2016-06"], "Slope Base Shallow Profiler"),
-    # AT50-29 2024: axial base shallow profiler
-    (["ctd 12"], "Axial Base Shallow Profiler"),
-    (["ctd 13"], "Axial Base Shallow Profiler"),
-    # AT50-29 2024: oregon offshore shallow profiler
-    (["ctd 009"], "Oregon Offshore Shallow Profiler"),
-    (["ctd 14"], "Oregon Offshore Shallow Profiler"),
-    #
-    # Generic keyword rules.
-    #
-    # Slope Base Junction Box
-    (["lv01a"], "Slope Base Junction Box LV01A"),
-    (["lj01a"], "Slope Base Junction Box LJ01A"),
-    (["bubble", "plume"], "Slope Base Junction Box LJ01A"),
-    # Slope Base Deep Profiler
-    (["slope", "base", "dp"], "Slope Base Deep Profiler"),
-    (["slope", "base", "deep"], "Slope Base Deep Profiler"),
-    # Slope Base Shallow Profiler
-    (["slope", "base"], "Slope Base Shallow Profiler"),
-    # Axial Base Deep Profiler
-    (["axial", "dp"], "Axial Base Deep Profiler"),
-    (["axial", "deep"], "Axial Base Deep Profiler"),
-    # Axial Base Shallow Profiler
-    (["axial"], "Axial Base Shallow Profiler"),
-    # Oregon Offshore Deep Profiler
-    (["offshore", "dp"], "Oregon Offshore Deep Profiler"),
-    (["offshore", "deep"], "Oregon Offshore Deep Profiler"),
-    (["offshore", "600"], "Oregon Offshore Deep Profiler"),
-    (["endurance", "dp"], "Oregon Offshore Deep Profiler"),
-    # Oregon Shelf BEP
-    (["shelf"], "Oregon Shelf BEP"),
-    # Oregon Offshore Shallow Profiler
-    (["offshore"], "Oregon Offshore Shallow Profiler"),
-    (["endurance"], "Oregon Offshore Shallow Profiler"),
+# Substrings (case-insensitive) that cause a CNV column to be omitted from output.
+COLUMN_IGNORE: list[str] = [
+    "error",
 ]
 
+# Matches a distance-offset suffix like " - 500 m SW" or " - 100 m N of Einstein's Grotto".
+_STATION_OFFSET_RE = re.compile(r"\s+-\s+\d+\s+m\b.*$")
 
-def lookup_station(location: str) -> str | None:
-    """
-    Return the canonical summary-samples.csv station name for a raw btl Location/Station value,
-    or None if no rule matches.
+# Matches the cruise portion and CTD portion of a CTD file key, separated by "_" or "-".
+_CTD_FILE_KEY_RE = re.compile(r"^(.+?)[-_](CTD-.+)$", re.IGNORECASE)
 
-    Each rule in LOCATION_STATION_RULES is checked in order; the first whose keywords are all
-    present (case-insensitively) in `location` wins.
-    """
-    lower = location.lower()
-    for keywords, station_name in LOCATION_STATION_RULES:
-        if all(kw in lower for kw in keywords):
-            return station_name
-    return None
-
-
-# Mapping from raw header keys to CSV column names.
-META_KEY_TO_COLUMN_MAP: dict[str, str] = {
-    "cruise": "Cruise",
-    "cast": "Cast",
-    "station": "Station",
-    "station_name": "Station",
-    "station_number": "Station",
-    "location": "Station",
-    "water_depth": "CTD Cast Water Depth [m]",
-    "depth": "CTD Depth [m]",
-    "date": "Start Time [UTC]",
-}
-
-
-def sanitise_key(column_name: str) -> str:
-    """
-    Convert an unmapped Sea-Bird column name to a safe JSON key by replacing every run of
-    non-alphanumeric characters with a single underscore.
-    """
-    return re.sub(r"[^A-Za-z0-9]+", "_", column_name).strip("_")
-
-
-def column_to_key(column_name: str) -> str:
-    """Return the JSON key for a Sea-Bird column name."""
-    if column_name in COLUMN_MAP:
-        return COLUMN_MAP[column_name]
-
-    return sanitise_key(column_name)
-
-
-def is_stdev_key(key: str) -> bool:
-    """Return `True` if `key` is a standard-deviation companion column."""
-    return key.endswith(" stdev") or key.endswith("_sdev")
-
-
-def stdev_key(measurement_key: str) -> str:
-    """
-    Return the standard-deviation companion key for a measurement key.
-
-    For keys that match CSV column names (contain spaces / brackets) the stdev is appended as a
-    suffix in a consistent way so downstream code can find it. For plain snake_case keys the _sdev
-    suffix is used.
-    """
-    if " " in measurement_key or "[" in measurement_key:
-        return measurement_key + " stdev"
-    return measurement_key + "_sdev"
-
-
-# Regex for a Sea-Bird user-comment metadata line.
-META_REGEX = re.compile(r"^\*\*\s+([A-Za-z ]+?):\s*(.*?)\s*$")
-
-# Regex for a system header line.
-SYS_REGEX = re.compile(r"^\*\s+([A-Za-z /()]+?)\s*=\s*(.*?)\s*$")
+# Regex for parsing "# name N = shortName: Description [units]" lines.
+_CNV_NAME_RE = re.compile(r"^#\s*name\s+(\d+)\s*=\s*(\S+)\s*:")
 
 # Month abbreviations used when parsing date strings.
 MONTHS = {
@@ -216,34 +96,68 @@ MONTHS = {
 }
 
 
-def parse_datetime(text: str, time_text: str) -> str | None:
+def normalize_ctd_file_key(key: str) -> str:
     """
-    Combine a date token like "Aug 06 2021" and a time token like "00:08:19" into an ISO-8601 UTC
-    string. Returns `None` on failure.
+    Strip hyphens from the cruise portion of a CTD file key and normalize the separator to "_".
+
+    Examples:
+        "TN-393_CTD-001" -> "TN393_CTD-001"
+        "AT42-12_CTD-003" -> "AT4212_CTD-003"
+        "TN422-CTD-009" -> "TN422_CTD-009"
+    """
+    match = _CTD_FILE_KEY_RE.match(key)
+    if match:
+        return match.group(1).replace("-", "") + "_" + match.group(2)
+    return key
+
+
+# Mapping from raw header keys to CSV column names.
+META_KEY_TO_COLUMN_MAP: dict[str, str] = {
+    "cruise": "Cruise",
+    "cast": "Cast",
+    "water_depth": "CTD Cast Water Depth [m]",
+    "depth": "CTD Cast Depth [m]",
+    "date": "Start Time [UTC]",
+}
+
+# Regex for a Sea-Bird user-comment metadata line.
+META_REGEX = re.compile(r"^\*\*\s+([A-Za-z ]+?):\s*(.*?)\s*$")
+
+# Regex for a system header line.
+SYS_REGEX = re.compile(r"^\*\s+([A-Za-z /()]+?)\s*=\s*(.*?)\s*$")
+
+
+def load_ctd_file_lookup(summary_path: Path) -> dict[str, tuple[str, list[str]]]:
+    """
+    Read the summary samples CSV and return a mapping from "CTD File" value (e.g. "TN326_CTD-001")
+    to a (station, assets) tuple, where assets is the ordered list of unique "Target Asset" values
+    associated with that CTD file.
     """
     try:
-        parts = text.split()
-        if len(parts) == 3:
-            month = MONTHS.get(parts[0].lower())
-            if month is None:
-                return None
-            day = int(parts[1])
-            year = int(parts[2])
-        else:
-            return None
+        text = summary_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.error("Cannot read summary file %s: %s", summary_path, exc)
+        return {}
 
-        hour, minute, second = (int(part) for part in time_text.split(":"))
-        return datetime(
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-            tzinfo=timezone.utc,
-        ).isoformat()
-    except Exception:
-        return None
+    mapping: dict[str, tuple[str, list[str]]] = {}
+    reader = csv.DictReader(text.splitlines())
+    for row in reader:
+        ctd_file = normalize_ctd_file_key((row.get("CTD File") or "").strip())
+        station = (row.get("Station") or "").strip()
+        asset = (row.get("Target Asset") or "").strip()
+        if not ctd_file or not station:
+            continue
+        if ctd_file not in mapping:
+            mapping[ctd_file] = (station, [])
+        if asset and asset not in mapping[ctd_file][1]:
+            mapping[ctd_file][1].append(asset)
+
+    log.info(
+        "Loaded %d CTD file → station/asset mappings from '%s'.",
+        len(mapping),
+        summary_path,
+    )
+    return mapping
 
 
 def parse_nmea_utc(value: str) -> str | None:
@@ -251,14 +165,21 @@ def parse_nmea_utc(value: str) -> str | None:
     Convert an NMEA UTC header string like "Jul 06 2015 15:59:45" to an ISO-8601 UTC string. Returns
     `None` on failure.
     """
+    from datetime import datetime, timezone
+
     try:
-        # Format: "Mon DD YYYY HH:MM:SS"
-        nmea_parts = value.split()
-        if len(nmea_parts) != 4:
+        parts = value.split()
+        if len(parts) != 4:
             return None
-        date_str = " ".join(nmea_parts[:3])  # "Jul 06 2015"
-        time_str = nmea_parts[3]  # "15:59:45"
-        return parse_datetime(date_str, time_str)
+        month = MONTHS.get(parts[0].lower())
+        if month is None:
+            return None
+        day = int(parts[1])
+        year = int(parts[2])
+        hour, minute, second = (int(part) for part in parts[3].split(":"))
+        return datetime(
+            year, month, day, hour, minute, second, tzinfo=timezone.utc
+        ).isoformat()
     except Exception:
         return None
 
@@ -283,6 +204,11 @@ def parse_nmea_coordinates(value: str) -> float | None:
         return None
 
 
+def column_name_for(short_name: str) -> str:
+    """Return the output column name for a CNV short column name, using case-insensitive lookup."""
+    return COLUMN_MAP.get(short_name.lower(), short_name)
+
+
 def coerce_number(value: str) -> float | str:
     """Try to parse `value` as float; return the original string on failure."""
     try:
@@ -291,285 +217,322 @@ def coerce_number(value: str) -> float | str:
         return value
 
 
-def parse(path: Path) -> list[dict[str, Any]]:
+def parse(
+    path: Path,
+    ctd_file_lookup: dict[str, tuple[str, list[str]]],
+    downsample: int | None = None,
+    downsample_by: str = "depth",
+    downsample_select: str = "average",
+) -> Iterator[dict[str, Any]]:
+    """Parse a single .cnv file and yield sample dicts."""
+    ctd_file_key = normalize_ctd_file_key(path.stem.split("__")[-1])
+    lookup = ctd_file_lookup.get(ctd_file_key)
+    if lookup is not None:
+        station = _STATION_OFFSET_RE.sub("", lookup[0]).strip()
+        assets = lookup[1]
+    else:
+        station = None
+        assets = []
+    if station is None:
+        log.warning(
+            "No station found in summary for CTD file %r (%s), skipping.",
+            ctd_file_key,
+            path,
+        )
+        return
+
     try:
-        text = path.read_text(encoding="latin-1")
+        file = path.open(encoding="latin-1")
     except OSError as exc:
         log.error("Cannot read %s: %s", path, exc)
-        return []
+        return
 
-    lines = text.splitlines()
+    with file:
+        # Parse header: metadata and column definitions (line by line).
+        # Use readline() instead of iteration so that tell()/seek() work later.
+        meta: dict[str, Any] = {}
+        columns: dict[int, str] = {}
+        found_end = False
 
-    #
-    # Extract header metadata values, which are values included in all samples.
-    #
-    meta: dict[str, Any] = {}
-
-    for line in path.open(encoding="latin-1"):
-        # User-defined comment fields:  ** Cruise: TN393
-        user_comment_match = META_REGEX.match(line)
-        if user_comment_match:
-            raw_key = re.sub(r"\s+", "_", user_comment_match.group(1).strip().lower())
-            value = user_comment_match.group(2).strip()
-            if value:
-                csv_key = META_KEY_TO_COLUMN_MAP.get(raw_key)
-                if csv_key:
-                    # "Station" can be supplied by multiple source keys, first wins.
-                    if csv_key not in meta:
-                        if csv_key == "Station":
-                            canonical = lookup_station(value)
-                            if canonical is not None:
-                                meta["Station"] = canonical
-                            else:
-                                log.warning(
-                                    "No station mapping found for location %r in %s, skipping.",
-                                    value,
-                                    path,
-                                )
-                        else:
-                            meta[csv_key] = value
-
-            continue
-
-        # System header fields.
-        sys_header_match = SYS_REGEX.match(line)
-        if sys_header_match:
-            raw_key = sys_header_match.group(1).strip().lower()
-            value = sys_header_match.group(2).strip()
-            if "nmea latitude" in raw_key:
-                coord = parse_nmea_coordinates(value)
-                if coord is not None:
-                    meta["Start Latitude [degrees]"] = coord
-            elif "nmea longitude" in raw_key:
-                coord = parse_nmea_coordinates(value)
-                if coord is not None:
-                    meta["Start Longitude [degrees]"] = coord
-            elif "nmea utc" in raw_key:
-                # Only use as Start Time fallback if not already set by ** Date
-                if "Start Time [UTC]" not in meta:
-                    iso_time = parse_nmea_utc(value)
-                    meta["Start Time [UTC]"] = (
-                        iso_time if iso_time is not None else value
-                    )
-            elif "software version" in raw_key:
-                meta["software_version"] = value
-            continue
-
-        # Stop scanning metadata once we hit the data section
-        if line.strip().startswith("Bottle") and "Date" in line:
-            break
-
-    # Find column header line and parse column names.
-    header_line_index: int | None = None
-    raw_columns: list[str] = []
-
-    for line_index, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("Bottle") and "Date" in stripped:
-            # Split on whitespace. The header uses fixed-width layout but whitespace splitting is
-            # reliable for the column names themselves.
-            raw_columns = stripped.split()
-            header_line_index = line_index
-            break
-
-    if "Station" not in meta:
-        return []
-
-    if header_line_index is None:
-        log.warning("No data header found in %s, skipping.", path)
-        return []
-
-    # Map Sea-Bird column names → clean JSON keys
-    json_keys = [column_to_key(column_name) for column_name in raw_columns]
-
-    #
-    # Parse data rows.
-    #
-    # The BTL format interleaves "avg" and "sdev" rows, but we really only care about the averages.
-    #
-    # The bottle number and date appear on the avg row; the time of day
-    # appears in the same column position as "Date" on the sdev row.
-    # We combine them into a single ISO timestamp.
-    #
-    # Skip the "Position  Time  ..." unit row immediately after the header.
-    data_start_index = header_line_index + 2
-    if data_start_index < len(lines) and "Position" in lines[data_start_index - 1]:
-        pass  # already correct — unit row was at header_line_index + 1
-
-    samples: list[dict[str, Any]] = []
-    row_index = data_start_index
-
-    while row_index < len(lines):
-        avg_line = lines[row_index]
-
-        # Skip blank lines
-        if not avg_line.strip():
-            row_index += 1
-            continue
-
-        if not avg_line.strip().endswith("(avg)"):
-            row_index += 1
-            continue
-
-        # Peek at the next non-empty line to get the sdev row.
-        sdev_line = ""
-        sdev_search_index = row_index + 1
-        while sdev_search_index < len(lines):
-            if lines[sdev_search_index].strip():
-                if lines[sdev_search_index].strip().endswith("(sdev)"):
-                    sdev_line = lines[sdev_search_index]
+        while True:
+            line = file.readline()
+            if not line:
                 break
-            sdev_search_index += 1
+            if line.strip() == "*END*":
+                found_end = True
+                break
 
-        # Parse the "avg" row, stripping the trailing "(avg)" marker before splitting.
-        avg_values_raw = avg_line.strip().rstrip("(avg)").strip()
-        # The first token is the bottle number, the next three tokens form the date ("Aug 06 2021"),
-        # then the remaining tokens are numeric values.
-        avg_tokens = avg_values_raw.split()
+            name_match = _CNV_NAME_RE.match(line)
+            if name_match:
+                column_index = int(name_match.group(1))
+                short_name = name_match.group(2)
+                if not any(short in short_name.lower() for short in COLUMN_IGNORE):
+                    columns[column_index] = column_name_for(short_name)
+                continue
 
-        # ---- Parse the sdev row ----------------------------------------
-        sdev_tokens: list[str] = []
-        if sdev_line:
-            sdev_values_raw = sdev_line.strip().rstrip("(sdev)").strip()
-            sdev_tokens = sdev_values_raw.split()
+            user_comment_match = META_REGEX.match(line)
+            if user_comment_match:
+                raw_key = re.sub(
+                    r"\s+", "_", user_comment_match.group(1).strip().lower()
+                )
+                value = user_comment_match.group(2).strip()
+                if value:
+                    csv_key = META_KEY_TO_COLUMN_MAP.get(raw_key)
+                    if csv_key and csv_key not in meta:
+                        meta[csv_key] = value
+                continue
 
-        # Reconstruct per-column token lists.
-        avg_column_tokens: list[str | None] = []
-        sdev_column_tokens: list[str | None] = []
+            sys_header_match = SYS_REGEX.match(line)
+            if sys_header_match:
+                raw_key = sys_header_match.group(1).strip().lower()
+                value = sys_header_match.group(2).strip()
+                if "nmea latitude" in raw_key:
+                    coord = parse_nmea_coordinates(value)
+                    if coord is not None:
+                        meta["CTD Cast Start Latitude [degrees]"] = coord
+                elif "nmea longitude" in raw_key:
+                    coord = parse_nmea_coordinates(value)
+                    if coord is not None:
+                        meta["CTD Cast Start Longitude [degrees]"] = coord
+                elif "nmea utc" in raw_key:
+                    if "Start Time [UTC]" not in meta:
+                        iso_time = parse_nmea_utc(value)
+                        meta["Start Time [UTC]"] = (
+                            iso_time if iso_time is not None else value
+                        )
+                continue
 
-        try:
-            # Append bottle number.
-            avg_column_tokens.append(avg_tokens[0])
-            # No bottle number on sdev row.
-            sdev_column_tokens.append(None)
+        if not found_end or not columns:
+            log.warning("No data header or columns found in %s, skipping.", path)
+            return
 
-            # Date is 3 tokens, time is 1.
-            date_text = " ".join(avg_tokens[1:4])
-            avg_column_tokens.append(date_text)
+        max_column = max(columns.keys())
 
-            time_text = sdev_tokens[0] if sdev_tokens else None
-            sdev_column_tokens.append(time_text)
-
-            # Remaining numeric columns, one token each.
-            for avg_token_index in range(4, len(avg_tokens)):
-                avg_column_tokens.append(avg_tokens[avg_token_index])
-            for sdev_token_index in range(1, len(sdev_tokens)):
-                sdev_column_tokens.append(sdev_tokens[sdev_token_index])
-
-        except IndexError:
-            log.warning(
-                "Malformed row in %s at line %d, skipping bottle.", path, row_index + 1
-            )
-            row_index = sdev_search_index + 1
-            continue
-
-        # Build the sample with "Station" and "Target Asset" at the front.
-        station = meta["Station"]
-        sample: dict[str, Any] = {
-            "Station": station,
-            "Target Asset": f"CTD Cast ({station})",
-            **{key: value for key, value in meta.items() if key != "Station"},
-        }
-
-        # Populate measured columns.
-        date_part: str = ""
-        time_part: str = ""
-
-        for column_index, json_key in enumerate(json_keys):
-            avg_text = (
-                avg_column_tokens[column_index]
-                if column_index < len(avg_column_tokens)
-                else None
-            )
-            sdev_text = (
-                sdev_column_tokens[column_index]
-                if column_index < len(sdev_column_tokens)
-                else None
-            )
-
-            if json_key == "_btl_bottle_number":
-                sample["CTD Cast Bottle Position"] = (
-                    int(avg_text) if avg_text is not None else None
+        # Find the depth column index for depth-based downsampling.
+        depth_column: int | None = None
+        if downsample is not None and downsample_by == "depth":
+            for column_index, column_name in columns.items():
+                if column_name == COLUMN_MAP.get("depsm"):
+                    depth_column = column_index
+                    break
+            if depth_column is None:
+                log.warning(
+                    "No depth column found in %s, falling back to time-based downsampling.",
+                    path,
                 )
 
-            elif json_key == "_btl_date":
-                # Defer writing the datetime until we also have the time.
-                date_part = avg_text or ""
-                time_part = sdev_text or ""
-
-            else:
-                # Numeric measurement, skip internal sentinel keys.
-                if json_key.startswith("_btl_"):
+        # Helper: read all data rows as parsed token lists.
+        def read_all_rows() -> list[list[str]]:
+            rows: list[list[str]] = []
+            while True:
+                line = file.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
                     continue
-                if avg_text is not None:
-                    sample[json_key] = coerce_number(avg_text)
-                if sdev_text is not None:
-                    sample[stdev_key(json_key)] = coerce_number(sdev_text)
+                tokens = line.split()
+                if len(tokens) > max_column:
+                    rows.append(tokens)
+            return rows
 
-        # Combine date and time into ISO-8601 UTC → "CTD Bottle Closure Time [UTC]".
-        if date_part and time_part:
-            iso = parse_datetime(date_part, time_part)
-            if iso:
-                sample["CTD Cast Bottle Closure Time [UTC]"] = iso
+        # Helper: build a sample dict from a token list.
+        def make_sample(tokens: list[str]) -> dict[str, Any]:
+            sample: dict[str, Any] = {
+                "Station": station,
+                "Target Asset": None,
+                **meta,
+            }
+            for column_index, column_name in columns.items():
+                sample[column_name] = coerce_number(tokens[column_index])
+            return sample
+
+        # Helper: average numeric columns across multiple token lists.
+        def average_tokens(group: list[list[str]]) -> list[str]:
+            result: list[str] = list(group[0])
+            for column_index in columns:
+                values: list[float] = []
+                for tokens in group:
+                    try:
+                        values.append(float(tokens[column_index]))
+                    except ValueError:
+                        pass
+                if values:
+                    result[column_index] = str(sum(values) / len(values))
+            return result
+
+        # Helper: yield sample dicts for each asset.
+        def emit(tokens: list[str]) -> Iterator[dict[str, Any]]:
+            sample = make_sample(tokens)
+            for asset in assets:
+                copy = dict(sample)
+                copy["Target Asset"] = asset
+                yield copy
+
+        # No downsampling: stream rows directly.
+        if downsample is None:
+            while True:
+                line = file.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                tokens = line.split()
+                if len(tokens) > max_column:
+                    yield from emit(tokens)
+            return
+
+        # --- Downsampling path: read all rows into memory for this file. ---
+        all_rows = read_all_rows()
+        if not all_rows:
+            return
+
+        if len(all_rows) <= downsample:
+            # Fewer rows than target: emit everything.
+            for tokens in all_rows:
+                yield from emit(tokens)
+            return
+
+        if downsample_by == "depth" and depth_column is not None:
+            # Compute evenly-spaced target depths.
+            depths = []
+            for i, tokens in enumerate(all_rows):
+                try:
+                    depths.append((i, float(tokens[depth_column])))
+                except ValueError:
+                    pass
+
+            if not depths:
+                return
+
+            min_depth = min(d for _, d in depths)
+            max_depth = max(d for _, d in depths)
+
+            if max_depth <= min_depth:
+                # All depths identical: just take evenly-spaced indices.
+                step = len(all_rows) / downsample
+                for i in range(downsample):
+                    yield from emit(all_rows[int(i * step)])
+                return
+
+            bin_size = (max_depth - min_depth) / downsample
+
+            if downsample_select == "average":
+                # Assign each row to a depth bin, then average each bin.
+                bins: dict[int, list[list[str]]] = {}
+                for row_index, depth in depths:
+                    bin_index = min(int((depth - min_depth) / bin_size), downsample - 1)
+                    bins.setdefault(bin_index, []).append(all_rows[row_index])
+
+                for bin_index in sorted(bins):
+                    yield from emit(average_tokens(bins[bin_index]))
             else:
-                sample["CTD Cast Bottle Closure Time [UTC]"] = (
-                    f"{date_part} {time_part}"
-                )
-        elif date_part:
-            sample["CTD Cast Bottle Closure Time [UTC]"] = date_part
+                # If "first", pick the nearest row to each target depth.
+                sorted_depths = sorted(depths, key=lambda entry: entry[1])
+                targets = [min_depth + i * bin_size for i in range(downsample)]
+                seen: set[int] = set()
+                cursor = 0
+                for target in targets:
+                    while (
+                        cursor < len(sorted_depths) - 1
+                        and sorted_depths[cursor][1] < target
+                    ):
+                        cursor += 1
+                    row_index = sorted_depths[cursor][0]
+                    if row_index not in seen:
+                        seen.add(row_index)
+                        yield from emit(all_rows[row_index])
+        else:
+            # Time-based, evenly-spaced row indices.
+            step = len(all_rows) / downsample
 
-        # Drop stdev keys before storing.
-        sample = {key: value for key, value in sample.items() if not is_stdev_key(key)}
-        samples.append(sample)
-        row_index = sdev_search_index + 1
-
-    return samples
+            if downsample_select == "average":
+                for i in range(downsample):
+                    start = int(i * step)
+                    end = int((i + 1) * step)
+                    group = all_rows[start:end] or [all_rows[start]]
+                    yield from emit(average_tokens(group))
+            else:
+                for i in range(downsample):
+                    yield from emit(all_rows[int(i * step)])
 
 
 def write_samples_as_json(
-    samples: list[dict[str, Any]],
+    samples: Iterator[dict[str, Any]],
     output: Path,
     indent: int,
-) -> None:
+) -> int:
+    """Stream samples to a JSON array file. Returns the number of samples written."""
+    count = 0
+    separator = ""
+    applied_indent = indent or None
+
     with output.open("w", encoding="utf-8") as stream:
-        json.dump(
-            samples,
-            stream,
-            indent=indent or None,
-            ensure_ascii=False,
-        )
-        stream.write("\n")
+        stream.write("[\n" if applied_indent else "[")
+
+        for sample in samples:
+            stream.write(separator)
+            json.dump(sample, stream, indent=applied_indent, ensure_ascii=False)
+            separator = ",\n" if applied_indent else ","
+            count += 1
+
+        stream.write("\n]\n" if applied_indent else "]")
+
+    return count
 
 
-def write_samples_as_csv(samples: list[dict[str, Any]], output: Path) -> None:
-
+def discover_columns(
+    files: list[Path],
+    ctd_file_lookup: dict[str, tuple[str, list[str]]],
+    downsample: int | None = None,
+    downsample_by: str = "depth",
+    downsample_select: str = "average",
+) -> list[str]:
+    """Do a quick pass over all files to collect the union of all column names in order."""
     columns: dict[str, None] = {}
-    for sample in samples:
-        # Add keys from all fields, values are updated here, but ignored. Preserve insertion order
-        # by using dictionary keys as an ordered set.
-        columns.update(sample)
+    for path in files:
+        for sample in parse(
+            path,
+            ctd_file_lookup,
+            downsample=downsample,
+            downsample_by=downsample_by,
+            downsample_select=downsample_select,
+        ):
+            columns.update(sample)
+            break  # Only need the first sample per file to get its columns.
+    return list(columns)
 
+
+def write_samples_as_csv(
+    samples: Iterator[dict[str, Any]],
+    output: Path,
+    columns: list[str],
+) -> int:
+    """Stream samples to a CSV file. Returns the number of samples written."""
+    count = 0
     with output.open("w", encoding="utf-8", newline="") as stream:
         writer = DictWriter(
             stream,
-            fieldnames=list(columns),
+            fieldnames=columns,
             extrasaction="ignore",
         )
         writer.writeheader()
-        writer.writerows(samples)
+        for sample in samples:
+            writer.writerow(sample)
+            count += 1
+    return count
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Convert all *.btl files under ROOT to a single JSON or CSV file.",
+        description="Convert all *.cnv files under ROOT to a single JSON or CSV file.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=dedent("""
           examples:
             # Write to the default output path (<root_name>.csv).
             ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/
             # Write to a JSON file (format inferred from extension).
-            ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/ --out ctd-cast-source-files.json
-            # Override format explicitly.
             ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/ --out ctd-cast-source-files.json
             # Use compact JSON output with no indentation.
             ./collect_discrete_ctd_cast_samples.py ./ctd-cast-sample-source-files/ --out ctd-cast-source-files.json --indent 0
@@ -579,7 +542,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "root",
         type=Path,
         metavar="ROOT",
-        help="Root directory to search recursively for *.btl files.",
+        help="Root directory to search recursively for *.cnv files.",
+    )
+    parser.add_argument(
+        "--summary-samples",
+        type=Path,
+        required=True,
+        metavar="SUMMARY_CSV",
+        help=(
+            "Path to the collected discrete summary samples CSV. Used to resolve the Station for "
+            "each CTD cast by matching the CTD file key in the .cnv filename against the "
+            "'CTD File' column."
+        ),
     )
     parser.add_argument(
         "--format",
@@ -607,6 +581,27 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="JSON indentation level, use 0 for compact output. (default: 2)",
     )
     parser.add_argument(
+        "--downsample-casts",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Maximum number of evenly-spaced samples to keep per cast. By default all samples are kept.",
+    )
+    parser.add_argument(
+        "--downsample-by",
+        choices=["depth", "time"],
+        default="depth",
+        help="Dimension along which to evenly space downsampled points: 'depth' for even depth "
+        "spacing, 'time' for even row-index spacing. (default: depth)",
+    )
+    parser.add_argument(
+        "--downsample-select",
+        choices=["average", "first"],
+        default="average",
+        help="How to select a value within each downsampling bin: 'average' averages all scans "
+        "in the bin, 'first' picks a single representative scan. (default: average)",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable DEBUG-level logging.",
@@ -627,11 +622,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if args.format is not None:
-        # The `--format` was explicitly provided, and takes priority.
         format = args.format
         out = args.out if args.out is not None else Path(f"{root.name}.{format}")
     elif args.out is not None:
-        # No explicit `--format`, infer from the file extension.
         extension = args.out.suffix.lower()[1:]
         if extension in {"csv", "json"}:
             format = extension
@@ -643,35 +636,65 @@ def main(argv: list[str] | None = None) -> int:
             format = "csv"
         out = args.out
     else:
-        # Neither `--format` or `--out` provided, use defaults.
         format = "csv"
         out = Path(f"{root.name}.csv")
 
-    files = sorted(root.rglob("*.btl"))
-    if not files:
-        log.error("No *.btl files found under '%s', exiting.", root)
+    if not args.summary_samples.exists():
+        log.error("Summary file '%s' does not exist.", args.summary_samples)
         return 1
 
-    log.info("Found %s *.btl file(s) under '%s'.", len(files), root)
+    ctd_file_lookup = load_ctd_file_lookup(args.summary_samples)
+    if not ctd_file_lookup:
+        log.error(
+            "No CTD file → station/asset mappings loaded from '%s', exiting.",
+            args.summary_samples,
+        )
+        return 1
 
-    samples: list[dict[str, Any]] = []
+    files = sorted(root.rglob("*.cnv"))
+    if not files:
+        log.error("No *.cnv files found under '%s', exiting.", root)
+        return 1
 
-    for file in files:
-        log.debug("Parsing '%s'.", file)
-        file_samples = parse(file)
-        log.info("  '%s' (%s sample(s))", file, len(file_samples))
-        samples.extend(file_samples)
+    log.info("Found %s *.cnv file(s) under '%s'.", len(files), root)
 
-    log.info("Parsed %s sample(s) from %s file(s).", len(samples), len(files))
+    downsample: int | None = args.downsample_casts
+    downsample_by: str = args.downsample_by
+    downsample_select: str = args.downsample_select
+
+    def stream() -> Iterator[dict[str, Any]]:
+        for file in files:
+            log.debug("Parsing '%s'.", file)
+            count = 0
+            for sample in parse(
+                file,
+                ctd_file_lookup,
+                downsample=downsample,
+                downsample_by=downsample_by,
+                downsample_select=downsample_select,
+            ):
+                count += 1
+                yield sample
+            log.info("  '%s' (%s sample(s))", file, count)
 
     out.parent.mkdir(parents=True, exist_ok=True)
 
     match format:
         case "csv":
-            write_samples_as_csv(samples, out)
+            columns = discover_columns(
+                files,
+                ctd_file_lookup,
+                downsample=downsample,
+                downsample_by=downsample_by,
+                downsample_select=downsample_select,
+            )
+            total = write_samples_as_csv(stream(), out, columns)
         case "json":
-            write_samples_as_json(samples, out, args.indent)
+            total = write_samples_as_json(stream(), out, args.indent)
+        case _:
+            total = 0
 
+    log.info("Wrote %s sample(s) from %s file(s).", total, len(files))
     log.info(f"'{out}': ({out.stat().st_size / 1024:.1f} KB)")
     return 0
 

--- a/scripts/collect_discrete_summary_samples.py
+++ b/scripts/collect_discrete_summary_samples.py
@@ -36,16 +36,34 @@ log = logging.getLogger(__name__)
 # Matches a distance-offset suffix like " - 500 m SW".
 _STATION_OFFSET_RE = re.compile(r"\s+-\s+\d+\s+m\b.*$")
 
-# Matches "CTD " at the start of a column name, but not "CTD File" or "CTD Bottle".
-_CTD_COLUMN_RE = re.compile(r"^CTD (?!File\b|Bottle\b)")
+# Substrings (case-insensitive) that cause a column to be omitted from output.
+COLUMN_IGNORE: list[str] = [
+    "bottle",
+]
+
+# Column renames applied to the output.
+COLUMN_RENAME: dict[str, str] = {
+    "Bottom Depth at Start Position [m]": "Water Depth [m]",
+}
+
+
+def _is_ignored_column(name: str) -> bool:
+    lower = name.lower()
+    return any(substring in lower for substring in COLUMN_IGNORE)
+
+
+def _rename_column(name: str) -> str:
+    return COLUMN_RENAME.get(name, name)
+
+
+def normalize_cast(value: str) -> str:
+    """Strip 'CTD-' prefix and leading zeros, returning the integer string or empty."""
+    value = re.sub(r"^CTD-", "", value.strip(), flags=re.IGNORECASE).lstrip("0") or "0"
+    return value if value.isdigit() else ""
 
 
 def strip_station_offset(station: str) -> str:
     return _STATION_OFFSET_RE.sub("", station).strip()
-
-
-def rename_ctd_column(name: str) -> str:
-    return _CTD_COLUMN_RE.sub("CTD Bottle ", name)
 
 
 def parse(
@@ -72,13 +90,24 @@ def parse(
     reader = csv.DictReader(lines)
 
     if columns is None:
-        columns = [rename_ctd_column(c) for c in (reader.fieldnames or [])]
+        columns = [
+            _rename_column(name) for name in (reader.fieldnames or [])
+            if not _is_ignored_column(name)
+        ]
 
     expanded: list[dict[str, Any]] = []
     for row in reader:
-        row = {rename_ctd_column(k): v for k, v in row.items()}
+        # Remove ignored columns and apply renames.
+        row = {
+            _rename_column(key): value
+            for key, value in row.items()
+            if not _is_ignored_column(key)
+        }
+
         if "Station" in row and row["Station"]:
             row["Station"] = strip_station_offset(row["Station"])
+        if "Cast" in row:
+            row["Cast"] = normalize_cast(row.get("Cast") or "")
 
         # Split the "Target Asset" column into individual assets, if present.
         raw_asset = row.get("Target Asset") or ""

--- a/scripts/collect_discrete_summary_samples.py
+++ b/scripts/collect_discrete_summary_samples.py
@@ -21,6 +21,7 @@ import argparse
 import csv
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from textwrap import dedent
@@ -31,6 +32,20 @@ logging.basicConfig(
     format="%(levelname)-8s %(message)s",
 )
 log = logging.getLogger(__name__)
+
+# Matches a distance-offset suffix like " - 500 m SW".
+_STATION_OFFSET_RE = re.compile(r"\s+-\s+\d+\s+m\b.*$")
+
+# Matches "CTD " at the start of a column name, but not "CTD File" or "CTD Bottle".
+_CTD_COLUMN_RE = re.compile(r"^CTD (?!File\b|Bottle\b)")
+
+
+def strip_station_offset(station: str) -> str:
+    return _STATION_OFFSET_RE.sub("", station).strip()
+
+
+def rename_ctd_column(name: str) -> str:
+    return _CTD_COLUMN_RE.sub("CTD Bottle ", name)
 
 
 def parse(
@@ -57,10 +72,31 @@ def parse(
     reader = csv.DictReader(lines)
 
     if columns is None:
-        columns = list(reader.fieldnames or [])
+        columns = [rename_ctd_column(c) for c in (reader.fieldnames or [])]
 
-    rows: list[dict[str, Any]] = list(reader)
-    return columns, rows
+    expanded: list[dict[str, Any]] = []
+    for row in reader:
+        row = {rename_ctd_column(k): v for k, v in row.items()}
+        if "Station" in row and row["Station"]:
+            row["Station"] = strip_station_offset(row["Station"])
+
+        # Split the "Target Asset" column into individual assets, if present.
+        raw_asset = row.get("Target Asset") or ""
+        assets = [
+            designator.strip()
+            for designator in raw_asset.split(",")
+            if designator.strip()
+        ]
+
+        if len(assets) <= 1:
+            expanded.append(row)
+        else:
+            for asset in assets:
+                copy = dict(row)
+                copy["Target Asset"] = asset
+                expanded.append(copy)
+
+    return columns, expanded
 
 
 def write_as_csv(

--- a/scripts/collect_discrete_summary_samples.py
+++ b/scripts/collect_discrete_summary_samples.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Concatenate all discrete summary CSV files under a given root directory into a single CSV/JSON
+file where every line/array element represents one sample.
+
+The header of the first file found is used as the output header. Rows from files whose header
+differs from the first are still included, missing fields are written as empty and extra fields
+are ignored.
+
+Usage:
+    ./collect_discrete_summary_samples.py ROOT [--out FILE] [--format {csv,json}] [--indent N] [--verbose]
+
+The output format is inferred from the extension of `--out` when it is ".csv" or ".json".
+
+If the extension is unrecognised, `--format` is used instead (default: csv).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)-8s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+
+def parse(
+    path: Path,
+    columns: list[str] | None,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Read `path` as a CSV file.
+
+    Returns a (columns, rows) tuple.  If `columns` is provided (i.e. this is not the first file) it
+    is used as the canonical column order. Rows with a differing header are still read but mapped
+    onto the canonical columns.
+    """
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        log.error("Cannot read %s: %s", path, exc)
+        return columns or [], []
+
+    lines = text.splitlines()
+    if not lines:
+        log.warning("'%s' is empty, skipping.", path)
+        return columns or [], []
+
+    reader = csv.DictReader(lines)
+
+    if columns is None:
+        columns = list(reader.fieldnames or [])
+
+    rows: list[dict[str, Any]] = list(reader)
+    return columns, rows
+
+
+def write_as_csv(
+    columns: list[str],
+    rows: list[dict[str, Any]],
+    output: Path,
+) -> None:
+    with output.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_as_json(
+    rows: list[dict[str, Any]],
+    output: Path,
+    indent: int,
+) -> None:
+    with output.open("w", encoding="utf-8") as stream:
+        json.dump(rows, stream, indent=indent or None, ensure_ascii=False)
+        stream.write("\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Combine all discrete sample summary *.csv files under ROOT into a single CSV or JSON file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=dedent("""
+          examples:
+            # Write to the default output path (<root_name>.csv).
+            ./collect_discrete_summary_samples.py ./source-data/summary-sample-source-files
+            # Write to a JSON file (format inferred from extension).
+            ./collect_discrete_summary_samples.py ./source-data/summary-sample-source-files --out summary-samples.json
+            # Override format explicitly.
+            ./collect_discrete_summary_samples.py ./source-data/summary-sample-source-files --format json
+            # Use compact JSON output with no indentation.
+            ./collect_discrete_summary_samples.py ./source-data/summary-sample-source-files --out summary-samples.json --indent 0
+        """),
+    )
+    parser.add_argument(
+        "root",
+        type=Path,
+        metavar="ROOT",
+        help="Root directory to search recursively for *.csv files.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["csv", "json"],
+        default=None,
+        dest="format",
+        help=(
+            "Output format: csv or json. Takes priority over the extension of `--out`. (default: csv)"
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help=(
+            "Output file path. Format is inferred from the extension (.csv or .json) when "
+            "recognised, otherwise `--format` is used. "
+            "Defaults to <root_directory_name>.csv in the current directory."
+        ),
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        metavar="N",
+        help="JSON indentation level, use 0 for compact output. (default: 2)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    root: Path = args.root
+    if not root.exists():
+        log.error("Root directory '%s' does not exist.", root)
+        return 1
+
+    if args.format is not None:
+        fmt = args.format
+        out = args.out if args.out is not None else Path(f"{root.name}.{fmt}")
+    elif args.out is not None:
+        extension = args.out.suffix.lower()[1:]
+        if extension in {"csv", "json"}:
+            fmt = extension
+        else:
+            log.warning(
+                "Unrecognised extension '.%s' in --out, defaulting to 'csv'.",
+                extension,
+            )
+            fmt = "csv"
+        out = args.out
+    else:
+        fmt = "csv"
+        out = Path(f"{root.name}.csv")
+
+    files = sorted(root.rglob("*.csv"))
+    if not files:
+        log.warning("No *.csv files found under '%s', exiting.", root)
+        return 0
+
+    log.info("Found %d *.csv file(s) under '%s'.", len(files), root)
+
+    columns: list[str] | None = None
+    rows: list[dict[str, Any]] = []
+
+    for file in files:
+        log.debug("Reading '%s'.", file)
+        columns, current_rows = parse(file, columns)
+        log.info("  '%s' (%d row(s))", file, len(current_rows))
+        rows.extend(current_rows)
+
+    log.info("Collected %d row(s) from %d file(s).", len(rows), len(files))
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    match fmt:
+        case "csv":
+            write_as_csv(columns or [], rows, out)
+        case "json":
+            write_as_json(rows, out, args.indent)
+
+    log.info("'%s': (%.1f KB)", out, out.stat().st_size / 1024)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/download_rawdata.py
+++ b/scripts/download_rawdata.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Recursively mirror https://rawdata-west.oceanobservatories.org/files/ into a local directory.
+
+Usage:
+    ./download_rawdata.py [GLOB] [--destination DIR] [--flatten] [--workers N] [--dry-run] [--verbose]
+
+    GLOB  Optional glob pattern for files to download, relative to the archive root,
+          e.g. "cruise_data/Cabled/*/Water_Sampling/CTD Data/*.btl"
+"""
+
+import argparse
+import fnmatch
+import logging
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.parse import unquote, urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from requests import Session
+from requests.exceptions import RequestException
+
+BASE_URL = "https://rawdata-west.oceanobservatories.org/files/"
+DEFAULT_DESTINATION = Path("raw")
+DEFAULT_WORKERS = 8
+CHUNK_SIZE = 1024 * 256  # 256 KiB
+RETRY_LIMIT = 3
+RETRY_BACKOFF = 2.0  # Seconds, doubles on each retry.
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+
+def is_directory_url(href: str) -> bool:
+    """Return True when the href points to a sub-directory (ends with '/')."""
+    return href.endswith("/")
+
+
+def url_to_relative_path(file_url: str) -> str:
+    """
+    Strip the BASE_URL prefix from a file URL and return the relative path string.
+
+    Percent-encoding (e.g. %20 = ' ') is decoded so callers always receive a plain text path.
+    """
+    parsed = urlparse(file_url)
+    remote_path = unquote(parsed.path)
+    prefix = "/files/"
+    if remote_path.startswith(prefix):
+        return remote_path[len(prefix) :]
+    return remote_path.lstrip("/")
+
+
+def glob_matches(relative_path: str, pattern: str | None) -> bool:
+    if pattern is None:
+        return True
+
+    return fnmatch.fnmatchcase(relative_path.lower(), pattern.lower())
+
+
+def directory_could_match(directory: str, pattern: str) -> bool:
+    """
+    Return True if descending into `directory` could ever yield a file that matches `pattern`.
+
+    Walks the leading segments of the pattern against the directory's relative path. Returns
+    `False` only when a segment is provably incompatible so we never prune a directory that might
+    contain matches. A '**' in the pattern always allows further descent.
+    """
+    relative_dir = url_to_relative_path(directory)
+    if not relative_dir:
+        return True
+
+    pattern_parts = pattern.replace("\\", "/").split("/")
+    directory_parts = relative_dir.rstrip("/").split("/")
+
+    for i, directory_segment in enumerate(directory_parts):
+        if i >= len(pattern_parts):
+            # Pattern is shallower than the directory, can't match deeper files.
+            return False
+        pattern_segment = pattern_parts[i]
+        if pattern_segment == "**":
+            # The '**' matches everything from here down.
+            return True
+
+        if not fnmatch.fnmatchcase(directory_segment.lower(), pattern_segment.lower()):
+            return False
+
+    return True
+
+
+def list_directory(
+    session: Session,
+    url: str,
+    start_url: str,
+) -> tuple[list[str], list[str]]:
+    """
+    Fetch an Apache-style directory listing and return absolute URLs of sub-directories and absolute
+    URLs of downloadable files.
+
+    The `start_url` is the root of the current crawl (used to reject links that escape back above
+    it).
+    """
+    directories: list[str] = []
+    files: list[str] = []
+
+    try:
+        resp = session.get(url, timeout=30)
+        resp.raise_for_status()
+    except RequestException as exc:
+        log.error("Failed to list %s: %s", url, exc)
+        return directories, files
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    for anchor in soup.find_all("a", href=True):
+        href: str = str(anchor["href"])
+
+        if (
+            href in ("../", "/")
+            or href.startswith("?")
+            or "Parent Directory" in anchor.text
+        ):
+            continue
+
+        # Resolve to absolute URL.
+        absolute = urljoin(url, href)
+        # Skip anything that escapes above the crawl root.
+        if not absolute.startswith(start_url):
+            continue
+
+        if is_directory_url(href):
+            directories.append(absolute)
+        else:
+            files.append(absolute)
+
+    return directories, files
+
+
+def crawl(
+    session: Session,
+    url: str,
+    glob: str | None = None,
+    *,
+    _start_url: str | None = None,
+) -> list[str]:
+    """
+    Recursively walk the remote directory tree starting at *url* and return
+    a flat list of all file URLs whose relative paths match *glob*.
+
+    Early pruning: if a glob pattern is given and its leading path segments
+    cannot possibly match a directory's relative path, that entire subtree is
+    skipped without being fetched.
+    """
+    if _start_url is None:
+        _start_url = url
+
+    all_files: list[str] = []
+    directories, files = list_directory(session, url, _start_url)
+
+    for file_url in files:
+        relative = url_to_relative_path(file_url)
+        if glob_matches(relative, glob):
+            all_files.append(file_url)
+        else:
+            log.debug("Skipping (glob mismatch): %s", relative)
+
+    for directory in directories:
+        if glob is not None and not directory_could_match(directory, glob):
+            log.debug("Ignoring directory '%s'.", directory)
+            continue
+
+        log.debug("Entering directory '%s'.", directory)
+        all_files.extend(crawl(session, directory, glob, _start_url=_start_url))
+
+    return all_files
+
+
+def get_local_path(file_url: str, destination: Path, flatten: bool = False) -> Path:
+    """Convert a remote file URL to the corresponding local Path under `destination`.
+
+    If `flatten` is True the directory structure is collapsed and path separators are
+    replaced with '__', so all files land directly in `destination`.
+    """
+    relative = url_to_relative_path(file_url)
+    if flatten:
+        return destination / relative.replace("/", "__")
+    return destination / relative
+
+
+def download_file(
+    session: Session,
+    url: str,
+    destination: Path,
+    flatten: bool = False,
+) -> tuple[str, str]:
+    """
+    Download `url` to `destination`, preserving the remote directory structure. Returns (url,
+    status) where status is 'ok', 'skipped', or 'error'.
+    """
+    local = get_local_path(url, destination, flatten=flatten)
+
+    if local.exists():
+        try:
+            head = session.head(url, timeout=15)
+            size = int(head.headers.get("Content-Length", -1))
+            if size > 0 and local.stat().st_size == size:
+                log.debug("Skipping (already complete): %s", local)
+                return url, "skipped"
+        except Exception:
+            pass
+
+    local.parent.mkdir(
+        parents=True, exist_ok=True
+    )  # no-op for the destination dir itself when flattened
+    tmp = local.with_suffix(local.suffix + ".part")
+
+    for attempt in range(1, RETRY_LIMIT + 1):
+        try:
+            with session.get(url, stream=True, timeout=60) as resp:
+                resp.raise_for_status()
+                with open(tmp, "wb") as fh:
+                    for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
+                        if chunk:
+                            fh.write(chunk)
+            tmp.rename(local)
+            log.info("Downloaded: %s", local)
+            return url, "ok"
+        except requests.RequestException as exc:
+            log.warning(
+                "Attempt %d/%d failed for %s: %s", attempt, RETRY_LIMIT, url, exc
+            )
+            if tmp.exists():
+                tmp.unlink()
+            if attempt < RETRY_LIMIT:
+                time.sleep(RETRY_BACKOFF * attempt)
+
+    log.error("Giving up on '%s'.", url)
+    return url, "error"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Mirror the OOI raw data archive (or a subdirectory) to a local folder.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  # Download CTD .btl files across every Cabled cruise.
+  ./download_rawdata.py 'cruise_data/Cabled/*/Water_Sampling/CTD Data/*.btl'
+
+  # Download summary .csv files for all Global cruises.
+  ./download_rawdata.py 'cruise_data/Cabled/*/Water_Sampling/*Discrete_Summary.csv'
+
+glob pattern notes:
+  Patterns are matched against the path relative to the archive root.
+  Matching is case-insensitive.
+    *      matches any characters within a single path segment
+    **     matches any characters including path separators
+    ?      matches any single character
+    [seq]  matches any character in seq
+        """,
+    )
+    parser.add_argument(
+        "glob",
+        nargs="?",
+        default=None,
+        metavar="GLOB",
+        help=(
+            "Glob pattern for files to download, relative to the archive root. "
+            "Supports *, **, ?, and [seq]. Defaults to all files. "
+            "Example: 'cruise_data/Cabled/*/Water_Sampling/CTD Data/*.btl'"
+        ),
+    )
+    parser.add_argument(
+        "--destination",
+        type=Path,
+        default=DEFAULT_DESTINATION,
+        metavar="DIR",
+        help=f"Local destination directory (default: {DEFAULT_DESTINATION})",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=DEFAULT_WORKERS,
+        metavar="N",
+        help=f"Number of parallel download threads (default: {DEFAULT_WORKERS})",
+    )
+    parser.add_argument(
+        "--flatten",
+        action="store_true",
+        help=(
+            "Store all files directly in the destination directory, replacing '/' in their "
+            "relative paths with '__' to form the filename."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    log.info("Start URL  : %s", BASE_URL)
+    log.info("Destination: %s", args.destination.resolve())
+    log.info("Workers    : %d", args.workers)
+    if args.glob:
+        log.info("Glob filter: %s", args.glob)
+    if args.flatten:
+        log.info("Flatten    : enabled")
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": "ooi-cruise-data-mirror/1.0"})
+
+    log.info("Crawling remote directory tree.")
+    file_urls = crawl(session, BASE_URL, glob=args.glob)
+    log.info("Found %d file(s) to download.", len(file_urls))
+
+    if not file_urls:
+        log.warning("No files found, nothing to do.")
+        return 0
+
+    counts: dict[str, int] = {"ok": 0, "skipped": 0, "error": 0}
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {
+            pool.submit(
+                download_file,
+                session,
+                url,
+                args.destination,
+                args.flatten,
+            ): url
+            for url in file_urls
+        }
+        for future in as_completed(futures):
+            _, status = future.result()
+            counts[status] = counts.get(status, 0) + 1
+
+    log.info(
+        "Done. downloaded=%d  skipped=%d  errors=%d",
+        counts["ok"],
+        counts["skipped"],
+        counts["error"],
+    )
+
+    return 1 if counts["error"] > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refresh-discrete-data.sh
+++ b/scripts/refresh-discrete-data.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Download source data files from the OOI raw data archive and parses them into the discrete sample
+# CSVs used by the dashboard. Writes to the following locations under `dashboard/public/`:
+#   - ctd-cast-samples.csv
+#   - summary-samples.csv
+#   - source-data/ctd-casts/ (for .btl files)
+#   - source-data/summaries/ (for *Discrete_Summary.csv files)
+#
+# Usage:
+#   ./refresh-discrete-data.sh [TYPE...] [--verbose]
+#
+# TYPE (optional, repeatable):
+#   ctd-cast   Refresh CTD cast samples (ctd-cast-samples.csv)
+#   summary    Refresh discrete summary samples (summary-samples.csv)
+#
+#   When no TYPE is given, both are refreshed.
+#
+# Options forwarded to download_rawdata.py:
+#   --verbose   Enable DEBUG-level logging in the download step.
+
+set -euo pipefail
+
+SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISCRETE_DIRECTORY="$SCRIPT_DIRECTORY/../dashboard/public/discrete"
+
+DOWNLOAD_SCRIPT="$SCRIPT_DIRECTORY/download_rawdata.py"
+
+TYPES=()
+DOWNLOAD_ARGS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        ctd-cast|summary)
+            TYPES+=("$arg")
+            ;;
+        --verbose)
+            DOWNLOAD_ARGS+=("--verbose")
+            ;;
+        -h|--help)
+            sed -n '2,/^[^#]/{ /^#/{ s/^# \{0,1\}//; p }; /^[^#]/q }' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [ctd-cast] [summary] [--verbose]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Default to both types when none are specified.
+if [ ${#TYPES[@]} -eq 0 ]; then
+    TYPES=(ctd-cast summary)
+fi
+
+refresh_ctd_cast() {
+    local source="$DISCRETE_DIRECTORY/source-data/ctd-casts"
+    local output="$DISCRETE_DIRECTORY/ctd-cast-samples.csv"
+    local glob="cruise_data/Cabled/*/Water_Sampling/CTD Data/*.btl"
+
+    echo "==> [ctd-cast] Downloading .btl files into '$source' ..."
+    python "$DOWNLOAD_SCRIPT" \
+        "$glob" \
+        --destination "$source" \
+        --flatten \
+        "${DOWNLOAD_ARGS[@]+"${DOWNLOAD_ARGS[@]}"}"
+
+    echo "==> [ctd-cast] Parsing .btl files into '$output' ..."
+    python "$SCRIPT_DIRECTORY/collect_discrete_ctd_cast_samples.py" \
+        "$source" \
+        --out "$output"
+    echo "==> [ctd-cast] Done. Output written to '$output'."
+}
+
+refresh_summary() {
+    local source="$DISCRETE_DIRECTORY/source-data/summaries"
+    local output="$DISCRETE_DIRECTORY/summary-samples.csv"
+    local glob="cruise_data/Cabled/*/Water_Sampling/*Discrete_Summary.csv"
+
+    echo "==> [summary] Downloading discrete summary CSV files into '$source' ..."
+    python "$DOWNLOAD_SCRIPT" \
+        "$glob" \
+        --destination "$source" \
+        --flatten \
+        "${DOWNLOAD_ARGS[@]+"${DOWNLOAD_ARGS[@]}"}"
+
+    echo "==> [summary] Collecting summary CSVs into '$output' ..."
+    python "$SCRIPT_DIRECTORY/collect_discrete_summary_samples.py" \
+        "$source" \
+        --out "$output"
+    echo "==> [summary] Done. Output written to '$output'."
+}
+
+for type in "${TYPES[@]}"; do
+    case "$type" in
+        ctd-cast) refresh_ctd_cast ;;
+        summary)  refresh_summary  ;;
+    esac
+done

--- a/scripts/refresh-discrete-data.sh
+++ b/scripts/refresh-discrete-data.sh
@@ -3,7 +3,7 @@
 # CSVs used by the dashboard. Writes to the following locations under `dashboard/public/`:
 #   - ctd-cast-samples.csv
 #   - summary-samples.csv
-#   - source-data/ctd-casts/ (for .btl files)
+#   - source-data/ctd-casts/ (for .cnv files)
 #   - source-data/summaries/ (for *Discrete_Summary.csv files)
 #
 # Usage:
@@ -56,18 +56,28 @@ fi
 refresh_ctd_cast() {
     local source="$DISCRETE_DIRECTORY/source-data/ctd-casts"
     local output="$DISCRETE_DIRECTORY/ctd-cast-samples.csv"
-    local glob="cruise_data/Cabled/*/Water_Sampling/CTD Data/*.btl"
+    local glob="cruise_data/Cabled/*/Water_Sampling/CTD Data/*.cnv"
 
-    echo "==> [ctd-cast] Downloading .btl files into '$source' ..."
+    echo "==> [ctd-cast] Downloading .cnv files into '$source' ..."
     python "$DOWNLOAD_SCRIPT" \
         "$glob" \
         --destination "$source" \
         --flatten \
         "${DOWNLOAD_ARGS[@]+"${DOWNLOAD_ARGS[@]}"}"
 
-    echo "==> [ctd-cast] Parsing .btl files into '$output' ..."
+    local summary="$DISCRETE_DIRECTORY/summary-samples.csv"
+    if [ ! -f "$summary" ]; then
+        echo "==> [ctd-cast] summary-samples.csv not found at '$summary', refreshing it first ..."
+        refresh_summary
+    fi
+
+    echo "==> [ctd-cast] Parsing .cnv files into '$output' ..."
     python "$SCRIPT_DIRECTORY/collect_discrete_ctd_cast_samples.py" \
         "$source" \
+        --summary-samples "$summary" \
+        --downsample-casts 200 \
+        --downsample-by depth \
+        --downsample-select average \
         --out "$output"
     echo "==> [ctd-cast] Done. Output written to '$output'."
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1735,15 +1735,19 @@ name = "qaqc-dashboard-environment"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "pip" },
     { name = "rca-data-tools" },
+    { name = "requests" },
     { name = "tqdm" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "pip" },
     { name = "rca-data-tools", git = "https://github.com/OOI-CabledArray/rca-data-tools.git" },
+    { name = "requests", specifier = ">=2.32.5" },
     { name = "tqdm" },
 ]
 


### PR DESCRIPTION
**Discrete Data Page Changes**

- Fetch the CTD cast and summary sample files from the server directly rather than reading an index of separate files. The samples now include a `type` to indicate whether they came from the CTD cast file or the summary samples file.
- CTD cast data is stored under Assets > "CTD Cast (station-name)"  in the "Asset" selector. Other strategies for handling this were very unintuitive, as having a split between instruments having an "Asset" name and CTD Casts only having a "Station" was very confusing. It seemed best to keep the filtering to just "Asset", though that may not be the best word anymore.
- Moved the R^2 value to the top right of the chart so it doesn't take up so much space.
- Changed the chart legend to "scroll" mode so it doesn't start overflowing the chart when there are a lot of series to defined.
- Added "Remove" and "Remove Other Assets" actions to the series' "..." menus.

**Backend Changes**

- Add scripts to `/scripts` directory to help with fetching and compiling data for the frontend to display.
    - `./scripts/refresh-discrete-data.sh`: Fetch CTD cast data and discrete summary files from `https://rawdata-west.oceanobservatories.org/files/` and subsequently parse them into files which can be read from the frontend: `dashboard/public/discrete/ctd-cast-samples.csv` and `dashboard/public/discrete/summary-samples.csv` respectively, which have both been added to the S3 bucket. This script uses the following scripts in its implementation:
    
    - `./scripts/scripts/download_rawdata.py`: Downloading subsets of the file tree from `https://rawdata-west.oceanobservatories.org/files/` into a local directory. Includes a `--flatten` flag which will include the paths of the files in the file names themselves, allowing a flat downloaded directory. Takes a glob as its first command line argument.
    - `./scripts/collect_discrete_ctd_cast_samples.py`: Read `.btl` files from a directory and parse them into a single large CSV or (JSON file if specified) sample file which can be read from the frontend. This uses a lot of very tedious parsing code and a lot of hackery to determine which "Station" and "Target Asset" to associate samples with, considering the "Station"/"Location" are almost never specified in the same way in the bottle files. Claude Code was used to figure out most of the initial parsing and name mapping which would have taken forever otherwise.
    - `./scripts/collect_discrete_summary_samples.py`: Read discrete data `.csv` files from a directory and combine them into a single large CSV or (JSON file if specified) sample file which can be read from the frontend. This one doesn't have much for fancy logic, it mostly just concatenates the files and works in a similar way to the CTD cast collection script.

